### PR TITLE
feat:pretendard 웹폰트추가

### DIFF
--- a/src/app/auth/sign-in/page.tsx
+++ b/src/app/auth/sign-in/page.tsx
@@ -1,3 +1,3 @@
 export default function SignIn() {
-  return <div>로그인페이지입니다</div>;
+  return <div>Welcome to 같이 달램!</div>;
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,6 +2,9 @@
 @tailwind components;
 @tailwind utilities;
 
+/* pretendard 웹폰트 적용 */
+@import url("https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable.min.css");
+
 :root {
   --background: #ffffff;
   --foreground: #171717;
@@ -17,7 +20,7 @@
 body {
   color: var(--foreground);
   background: var(--background);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: "Pretendard Variable", Pretendard, Arial, Helvetica, sans-serif;
 }
 
 .header-link {


### PR DESCRIPTION
## Description

웹폰트 적용 안되어있길래 피그마에 나와있는 pretendard 웹폰트 추가했습니다

## Changes Made


- [x] 기능 추가: ✅
- [x] 버그 수정: 🐛
- [x] 코드 리팩토링: 🔧
- [x] 문서 업데이트: 📝

## Screenshots (선택)

[UI 변경사항이 있다면 스크린샷을 추가해주세요.]

## IssueNumber

[#이슈번호]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
	- 로그인 페이지의 환영 메시지가 "로그인페이지입니다"에서 "Welcome to 같이 달램!"으로 변경되었습니다.
- **스타일**
	- 글로벌 스타일이 업데이트되어 Pretendard Variable 웹폰트가 적용되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->