### PR TITLE
LikeButton props 수정

### DIFF
--- a/src/components/LikeButton.tsx
+++ b/src/components/LikeButton.tsx
@@ -2,16 +2,15 @@
 
 import Heart from "@/images/heart.svg";
 import Bye from "@/images/bye.svg";
-import { useState } from "react";
+import { ButtonHTMLAttributes, useState } from "react";
 
 type LikeButtonProps = {
   onClick: () => void;
   isClosed: boolean;
-};
+} & ButtonHTMLAttributes<HTMLButtonElement>;
 
-export default function LikeButton({ onClick, ...rest }: LikeButtonProps) {
+export default function LikeButton({ onClick, isClosed, ...rest }: LikeButtonProps) {
   // 모임이 마감, 취소된 경우
-  const { isClosed } = rest;
   const [clicked, setClicked] = useState(false);
   const handleClick = () => {
     setClicked(!clicked);
@@ -21,6 +20,7 @@ export default function LikeButton({ onClick, ...rest }: LikeButtonProps) {
     <button
       className={`group flex ${isClosed ? "h-9 w-full max-w-[116px] sm:size-12" : "size-12"} items-center justify-center rounded-full ${clicked || isClosed ? "border-0 bg-orange-50" : "border-2 bg-white"} border-gray-200`}
       onClick={handleClick}
+      {...rest}
     >
       {/* 모임이 마감, 취소된 경우 Bye와 span을, 아닌 경우 Heart를 렌더링  */}
       {isClosed ? (


### PR DESCRIPTION
## Description

LikeButton에서 isClosed를 받아오는 방법을 수정했습니다.

## Changes Made

[변경사항 리스트를 적습니다.]

- [x] 코드 리팩토링: 🔧

- 기존에 rest에서 구조분해할당하던 `isClosed` 를 props에 명시했습니다. 이외에 큰 변경사항은 없습니다.

## Screenshots (선택)

[UI 변경사항이 있다면 스크린샷을 추가해주세요.]

## IssueNumber

#16 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **리팩터**
	- 좋아요 버튼이 추가 버튼 속성 사용을 지원하도록 개선되어, 보다 유연한 조작이 가능합니다.
	- 버튼 상태에 따라 아이콘이 조건부로 표시되어, 일관된 사용자 경험을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->