### PR TITLE
feat: chip info 날짜, 시간으로 변경

### DIFF
--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -60,7 +60,7 @@ export default function Card({
         </div>
 
         {/* 날짜 정보 */}
-        <ChipInfo dateTime={dateTime} registrationEnd={registrationEnd} />
+        <ChipInfo dateTime={dateTime} />
 
         {/* 인원 정보 */}
         <p className="mt-5 text-sm text-gray-500">

--- a/src/components/ChipInfo.tsx
+++ b/src/components/ChipInfo.tsx
@@ -1,9 +1,8 @@
 type ChipInfoProps = {
   dateTime: string;
-  registrationEnd: string;
 };
 
-export default function ChipInfo({ dateTime, registrationEnd }: ChipInfoProps) {
+export default function ChipInfo({ dateTime }: ChipInfoProps) {
   // 날짜를 "MM-DD" 형식으로 변환하는 함수
   const formatDate = (dateString: string) => {
     const date = new Date(dateString);
@@ -12,15 +11,23 @@ export default function ChipInfo({ dateTime, registrationEnd }: ChipInfoProps) {
     return `${month}월 ${day}일`;
   };
 
+  // 시간를 "HH:MM" 형식으로 변환하는 함수
+  const formatTime = (dateString: string) => {
+    const date = new Date(dateString);
+    const hours = String(date.getHours()).padStart(2, "0");
+    const minutes = String(date.getMinutes()).padStart(2, "0");
+    return `${hours}:${minutes}`;
+  };
+
   return (
     <div className="flex gap-2">
       <div className="h-[24px] w-[58px] rounded-sm bg-gray-900">
-        {/* dateTime */}
+        {/* 날짜 */}
         <div className="mt-1 text-center text-xs font-medium text-white">{formatDate(dateTime)}</div>
       </div>
       <div className="h-[24px] w-[58px] rounded-sm bg-gray-900">
-        {/* registrationEnd */}
-        <div className="mt-1 text-center text-xs font-medium text-orange-500">{formatDate(registrationEnd)}</div>
+        {/* 시간 */}
+        <div className="mt-1 text-center text-xs font-medium text-orange-500">{formatTime(dateTime)}</div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Description

모임 카드에서 날짜, 마감일을 보여주던 chip을 모임 날짜와 모임 시간을 보여주는 것으로 변경하였습니다. 

## Changes Made

[변경사항 리스트를 적습니다.]

-  기능 추가: ✅
- 버그 수정: 🐛
- [x] 코드 리팩토링: 🔧
- 문서 업데이트: 📝

## IssueNumber

[#이슈번호]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **리팩터**
	- 카드 요소에서 등록 종료 정보를 제거하고, 대신 이벤트 시간을 "HH:MM" 형식으로 표시하도록 개선하였습니다.
	- 칩 요소에 전달되는 데이터가 단순화되어 UI의 일관성과 가독성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->