### PR TITLE
feat: 프로필 이미지 컴포넌트

### DIFF
--- a/src/components/Avatar.tsx
+++ b/src/components/Avatar.tsx
@@ -8,7 +8,7 @@ type AvatarProps = {
   size?: number;
 };
 
-export default function Avatar({ imageUrl, size = 30 }: AvatarProps) {
+export default function Avatar({ imageUrl, size = 40 }: AvatarProps) {
   const [isError, setIsError] = useState(false);
   const DEFAULT_IMAGE = "/images/profile.svg";
 

--- a/src/components/Avatar.tsx
+++ b/src/components/Avatar.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useState } from "react";
+import Image from "next/image";
+
+type AvatarProps = {
+  imageUrl?: string;
+  size?: number;
+};
+
+export default function Avatar({ imageUrl, size = 30 }: AvatarProps) {
+  const [isError, setIsError] = useState(false);
+  const DEFAULT_IMAGE = "/images/profile.svg";
+
+  return (
+    <div className="relative">
+      <Image
+        src={isError || !imageUrl ? DEFAULT_IMAGE : imageUrl}
+        alt={"프로필 이미지"}
+        width={size}
+        height={size}
+        className="rounded-full"
+        onError={() => setIsError(true)}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Description

프로필 이미지 컴포넌트 구현하였습니다.

## Changes Made

- [x] 기능 추가: ✅

```
imageUrl?: string;
size?: number;
```

``` tsx
<Avatar />
```


## Screenshots (선택)

<img width="145" alt="스크린샷 2025-02-11 오후 3 27 23" src="https://github.com/user-attachments/assets/e5680d16-fa82-4b61-8823-dd01a92c191a" />

아래 수정 아이콘 있는건 아직 없는데 나중에 추가할게요..!

## IssueNumber



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 새로운 프로필 이미지 구성 요소가 추가되어, 제공된 이미지 URL에 따라 이미지를 표시하며, 로딩 오류 발생 시 기본 이미지를 자동으로 보여줍니다.
	- 이미지 크기를 사용자 설정에 맞게 조절할 수 있는 옵션을 지원합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->