### PR TITLE
common레이아웃 구현

### DIFF
--- a/src/app/(common)/layout.tsx
+++ b/src/app/(common)/layout.tsx
@@ -1,0 +1,5 @@
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="mx-auto w-full max-w-[1200px] flex-1 sm:px-4 md:px-6 lg:bg-gray-50 lg:px-[102px]">{children}</div>
+  );
+}

--- a/src/app/(common)/mypage/page.tsx
+++ b/src/app/(common)/mypage/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div></div>;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -23,11 +23,11 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="ko">
-      <body className={`${pretendard.variable} font-pretendard`}>
+      <body className={`${pretendard.variable} bg-gray-100 font-pretendard`}>
         <Providers>
           <div>
             <Header />
-            <main>{children}</main>
+            <main className="flex min-h-screen flex-col pt-[56px]">{children}</main>
           </div>
         </Providers>
       </body>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 
 export default function Header() {
   return (
-    <header className="h-[56px] border-b-2 border-black bg-orange-600 px-4 md:h-[60px]">
+    <header className="fixed left-0 right-0 top-0 z-50 h-[56px] border-b-2 border-black bg-orange-600 px-4 md:h-[60px]">
       <div className="m-auto flex h-full max-w-[1200px] flex-row items-center justify-between">
         <nav className="flex h-full flex-row items-center gap-3 md:gap-6">
           {/* 768px 이하에서 보이는 로고 */}


### PR DESCRIPTION
## Description

- 로그인/회원가입을 제외한 페이지들의 레이아웃을 구현했습니다. 라우트 그룹을 생성한건데 적당한 이름을 짓기가 힘들어서... (auth)가 있으니 (common)으로 지었습니다.
- (auth) 제외한 라우팅은 (common) 아래에서 해야지 해당 레이아웃 적용됩니다.
- 헤더를 fixed로 만들었는데, 상단에 계속 고정시키는게 낫다 싶으면 다시 바꾸겠습니다.
## Changes Made

[변경사항 리스트를 적습니다.]

- [x] 기능 추가: ✅

- Header에 fixed 및 z-index 설정
- 루트 레이아웃에 최소 height와 배경색 설정
- common폴더 및 레이아웃 생성
- mypage 폴더를 (common)으로 이동

## Screenshots (선택)

<img width="1477" alt="스크린샷 2025-02-12 오전 10 04 57" src="https://github.com/user-attachments/assets/8fccd6be-078c-4971-aa7f-ed8c3414b20f" />
<img width="1487" alt="스크린샷 2025-02-12 오전 10 05 42" src="https://github.com/user-attachments/assets/a3da3612-9c27-4cb4-9599-13cac9606048" />

## IssueNumber

#57 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 사용자 콘텐츠 배치를 위한 새로운 레이아웃 도구 도입
  - 기본 페이지 템플릿 추가

- **스타일**
  - 전체 레이아웃의 배경 및 여백을 개선하여 반응형 디자인 강화
  - 헤더를 고정 처리해 스크롤 시에도 항상 상단에 노출되도록 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->