### PR TITLE
LikeButton에 isLiked props 추가

### DIFF
--- a/src/components/LikeButton.tsx
+++ b/src/components/LikeButton.tsx
@@ -11,14 +11,14 @@ type LikeButtonProps = {
 } & ButtonHTMLAttributes<HTMLButtonElement>;
 
 export default function LikeButton({ onClick, isClosed, isLiked, ...rest }: LikeButtonProps) {
-  const [clicked, setClicked] = useState(isLiked);
+  const [isClicked, setIsClicked] = useState(isLiked);
   const handleClick = () => {
-    setClicked(!clicked);
+    setIsClicked(!isClicked);
     onClick();
   };
   return (
     <button
-      className={`group flex ${isClosed ? "h-9 w-full max-w-[116px] sm:size-12" : "size-12"} items-center justify-center rounded-full ${clicked || isClosed ? "border-0 bg-orange-50" : "border-2 bg-white"} border-gray-200`}
+      className={`group flex ${isClosed ? "h-9 w-full max-w-[116px] sm:size-12" : "size-12"} items-center justify-center rounded-full ${isClicked || isClosed ? "border-0 bg-orange-50" : "border-2 bg-white"} border-gray-200`}
       onClick={handleClick}
       {...rest}
     >
@@ -32,7 +32,7 @@ export default function LikeButton({ onClick, isClosed, isLiked, ...rest }: Like
         <Heart
           fill="#fff"
           stroke="#9CA3AF"
-          className={`transition-all ${clicked ? "animate-heart-scale-up fill-red-600 stroke-none" : ""}`}
+          className={`transition-all ${isClicked ? "animate-heart-scale-up fill-red-600 stroke-none" : ""}`}
         />
       )}
     </button>

--- a/src/components/LikeButton.tsx
+++ b/src/components/LikeButton.tsx
@@ -5,13 +5,13 @@ import Bye from "@/images/bye.svg";
 import { ButtonHTMLAttributes, useState } from "react";
 
 type LikeButtonProps = {
-  onClick: () => void;
-  isClosed: boolean;
+  onClick: () => void; // 버튼 클릭 시 실행될 함수
+  isClosed: boolean; // 이미 마감, 취소된경우
+  isLiked: boolean; // 찜해놓은 경우
 } & ButtonHTMLAttributes<HTMLButtonElement>;
 
-export default function LikeButton({ onClick, isClosed, ...rest }: LikeButtonProps) {
-  // 모임이 마감, 취소된 경우
-  const [clicked, setClicked] = useState(false);
+export default function LikeButton({ onClick, isClosed, isLiked, ...rest }: LikeButtonProps) {
+  const [clicked, setClicked] = useState(isLiked);
   const handleClick = () => {
     setClicked(!clicked);
     onClick();


### PR DESCRIPTION
## Description

LikeButton에 찜 상태를 나타내는 isLiked props 를 추가하고 `useState` 의 초기값으로 전달했습니다.

## Changes Made

[변경사항 리스트를 적습니다.]

- [x] 기능 추가: ✅

- isLiked를 props로 받아 상태의 초기값으로 넘겨주도록 했습니다.
- 상태 이름을 isClicked로 바꿨습니다.

## Screenshots (선택)

[UI 변경사항이 있다면 스크린샷을 추가해주세요.]

## IssueNumber

#16


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 좋아요 버튼이 외부 입력에 따라 초기 좋아요 상태를 반영하여, 이미 선택된 상태로 표시될 수 있습니다.
- **리팩터**
  - 버튼의 상태 전환 로직이 개선되어, 클릭 시 더욱 일관된 사용자 피드백을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->