### PR TITLE
feat: 마감된 모임 찾기 화면 출력 X, 모임 날짜 순 정렬 추가

### DIFF
--- a/src/app/_home/CardList.tsx
+++ b/src/app/_home/CardList.tsx
@@ -41,6 +41,11 @@ export default function CardList() {
     };
   }, [handleObserver]);
 
+  // 마감되지 않은 모임만 필터링
+  const filteredCards = data?.pages.flatMap((page) =>
+    page.data.filter((card) => !card.registrationEnd || new Date(card.registrationEnd) >= new Date()),
+  );
+
   return (
     <div>
       <div className="mb-5 flex gap-6 pt-8">
@@ -64,20 +69,19 @@ export default function CardList() {
       <div className="px-6">
         <GatheringFilters onChange={setFilters} />
 
-        {data?.pages[0].data.length === 0 ? (
+        {data?.pages[0].data.length === 0 || filteredCards?.length === 0 ? (
           <div className="flex h-[calc(100vh-50vh)] flex-col items-center justify-center text-center text-sm font-medium text-gray-500">
             <p>아직 모임이 없어요</p>
             <p className="mt-2">지금 바로 모임을 만들어보세요</p>
           </div>
         ) : (
-          <div>
-            {data?.pages.map((page) =>
-              page.data
-                .filter((card) => !card.registrationEnd || new Date(card.registrationEnd) >= new Date())
-                .map((card) => <Card key={card.id} {...card} registrationEnd={card.registrationEnd ?? ""} />),
-            )}
+          <>
+            {filteredCards?.map((card) => (
+              <Card key={card.id} {...card} registrationEnd={card.registrationEnd ?? ""} />
+            ))}{" "}
+            {/* 무한 스크롤 감지용 div */}
             <div ref={observerRef} className="h-10"></div>
-          </div>
+          </>
         )}
         {isFetchingNextPage && <div className="text-center text-sm text-gray-500">더 불러오는 중...</div>}
       </div>

--- a/src/app/_home/CardList.tsx
+++ b/src/app/_home/CardList.tsx
@@ -72,7 +72,9 @@ export default function CardList() {
         ) : (
           <div>
             {data?.pages.map((page) =>
-              page.data.map((card) => <Card key={card.id} {...card} registrationEnd={card.registrationEnd ?? ""} />),
+              page.data
+                .filter((card) => !card.registrationEnd || new Date(card.registrationEnd) >= new Date())
+                .map((card) => <Card key={card.id} {...card} registrationEnd={card.registrationEnd ?? ""} />),
             )}
             <div ref={observerRef} className="h-10"></div>
           </div>

--- a/src/components/Filtering/SortButton.tsx
+++ b/src/components/Filtering/SortButton.tsx
@@ -10,14 +10,17 @@ type SortButtonProps = {
 const sortOption = [
   { label: "마감 임박", value: "registrationEnd" },
   { label: "참여 인원 순", value: "participantCount" },
+  { label: "모임 날짜 순", value: "dateTime" },
 ] as const;
 
 export default function SortButton({ setSortType }: SortButtonProps) {
   const [isSortDropdownOpen, setSortDropdownOpen] = useState(false);
-  const [selectedSort, setSelectedSort] = useState<"registrationEnd" | "participantCount">("registrationEnd");
+  const [selectedSort, setSelectedSort] = useState<"registrationEnd" | "participantCount" | "dateTime">(
+    "registrationEnd",
+  );
 
   // 정렬 옵션 선택
-  const handleSort = (sortType: "registrationEnd" | "participantCount") => {
+  const handleSort = (sortType: "registrationEnd" | "participantCount" | "dateTime") => {
     setSelectedSort(sortType);
     setSortDropdownOpen(false);
     setSortType(sortType); // 선택한 정렬 기준을 상위 컴포넌트에 전달
@@ -33,14 +36,20 @@ export default function SortButton({ setSortType }: SortButtonProps) {
         <div className="mr-1">
           <SortIcon />
         </div>
-        <span className="hidden md:block">{selectedSort === "registrationEnd" ? "마감 임박" : "참여 인원 순"}</span>
+        <span className="hidden md:block">
+          {selectedSort === "registrationEnd"
+            ? "마감 임박"
+            : selectedSort === "participantCount"
+              ? "참여 인원 순"
+              : "모임 날짜 순"}
+        </span>
       </button>
 
       {/* 드롭다운 메뉴 */}
       {isSortDropdownOpen && (
         <div className="absolute z-10 w-[110px] rounded-lg border bg-white p-2 text-sm font-medium shadow-md">
           {sortOption.map(({ label, value }) => (
-            <div key={value} onClick={() => handleSort(value)} className="rounded-lg p-2 hover:bg-orange-100">
+            <div key={value} onClick={() => handleSort(value)} className="rounded-lg p-2 hover:bg-sky-100">
               {label}
             </div>
           ))}


### PR DESCRIPTION
## Description

모집 마감일이 지난 모임은 모임 찾기 페이지에서 출력되지 않습니다.
모임 날짜 순으로 모임을 정렬할 수 있도록 카테고리를 추가했습니다. 

## Changes Made

- [x] 기능 추가: ✅

## Screenshots (선택)

## IssueNumber

#107 
