### PR TITLE
Fix: infinite scroll Hook 분리

### DIFF
--- a/src/app/(common)/_home/CardList.tsx
+++ b/src/app/(common)/_home/CardList.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useEffect, useCallback } from "react";
+import { useState } from "react";
 import CreateGatheringsModal from "@/app/(common)/_home/_components/CreateGatheringsModal";
 import ServiceTab from "@/app/(common)/_home/_components/ServiceTab";
 import GatheringFilters from "@/app/(common)/_home/_components/GatheringFilters";
@@ -8,6 +8,7 @@ import Card from "@/components/Card";
 import Button from "@/components/Button";
 import GatheringLogo from "@/images/gathering_logo.svg";
 import { useFetchGatherings } from "@/app/(common)/_home/_hooks/useFetchGatherings";
+import { useInfiniteScroll } from "@/hooks/useInfiniteScroll";
 
 export default function CardList() {
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -18,28 +19,8 @@ export default function CardList() {
   const handleOpen = () => setIsModalOpen(true);
   const handleClose = () => setIsModalOpen(false);
 
-  // 무한 스크롤을 감지할 ref
-  const observerRef = useRef<HTMLDivElement | null>(null);
-
-  const handleObserver = useCallback(
-    (entries: IntersectionObserverEntry[]) => {
-      const target = entries[0];
-      if (target.isIntersecting && hasNextPage && !isFetchingNextPage) {
-        fetchNextPage(); // 다음 데이터 요청
-      }
-    },
-    [fetchNextPage, hasNextPage, isFetchingNextPage],
-  );
-
-  useEffect(() => {
-    const observer = new IntersectionObserver(handleObserver, { threshold: 1.0 });
-
-    if (observerRef.current) observer.observe(observerRef.current);
-
-    return () => {
-      if (observerRef.current) observer.unobserve(observerRef.current);
-    };
-  }, [handleObserver]);
+  // 무한 스크롤 훅 사용
+  const { observerRef } = useInfiniteScroll({ fetchNextPage, hasNextPage, isFetchingNextPage });
 
   // 마감되지 않은 모임만 필터링
   const filteredCards = data?.pages.flatMap((page) =>

--- a/src/app/(common)/favorites/page.tsx
+++ b/src/app/(common)/favorites/page.tsx
@@ -3,6 +3,7 @@
 import { useRef, useEffect, useCallback } from "react";
 import { useFavoritesStore } from "@/stores/useFavoritesStore";
 import { useFetchGatherings } from "../_home/_hooks/useFetchGatherings";
+import { useInfiniteScroll } from "@/hooks/useInfiniteScroll";
 import Card from "@/components/Card";
 import ServiceTab from "@/app/(common)/_home/_components/ServiceTab";
 import FavoritesLogo from "@/images/favorites_logo.svg";
@@ -18,28 +19,8 @@ export default function Page() {
   // 찜한 목록에 해당하는 카드만 필터링
   const favoriteCards = allCards.filter((card) => favorites.includes(card.id.toString()));
 
-  // 무한 스크롤을 감지할 ref
-  const observerRef = useRef<HTMLDivElement | null>(null);
-
-  const handleObserver = useCallback(
-    (entries: IntersectionObserverEntry[]) => {
-      const target = entries[0];
-      if (target.isIntersecting && hasNextPage && !isFetchingNextPage) {
-        fetchNextPage(); // 다음 데이터 요청
-      }
-    },
-    [fetchNextPage, hasNextPage, isFetchingNextPage],
-  );
-
-  useEffect(() => {
-    const observer = new IntersectionObserver(handleObserver, { threshold: 1.0 });
-
-    if (observerRef.current) observer.observe(observerRef.current);
-
-    return () => {
-      if (observerRef.current) observer.unobserve(observerRef.current);
-    };
-  }, [handleObserver]);
+  // 무한 스크롤 hook
+  const { observerRef } = useInfiniteScroll({ fetchNextPage, hasNextPage, isFetchingNextPage });
 
   return (
     <div className="w-full">

--- a/src/app/(common)/favorites/page.tsx
+++ b/src/app/(common)/favorites/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useRef, useEffect, useCallback } from "react";
 import { useFavoritesStore } from "@/stores/useFavoritesStore";
 import { useFetchGatherings } from "../_home/_hooks/useFetchGatherings";
 import { useInfiniteScroll } from "@/hooks/useInfiniteScroll";

--- a/src/hooks/useInfiniteScroll.ts
+++ b/src/hooks/useInfiniteScroll.ts
@@ -21,13 +21,22 @@ export const useInfiniteScroll = ({ fetchNextPage, hasNextPage, isFetchingNextPa
   );
 
   useEffect(() => {
-    const observer = new IntersectionObserver(handleObserver, { threshold: 1.0 });
+    if (!window.IntersectionObserver) {
+      console.warn("IntersectionObserver is not supported in this browser");
+      return;
+    }
 
-    if (observerRef.current) observer.observe(observerRef.current);
+    try {
+      const observer = new IntersectionObserver(handleObserver, { threshold: 1.0 });
 
-    return () => {
-      if (observerRef.current) observer.unobserve(observerRef.current);
-    };
+      if (observerRef.current) observer.observe(observerRef.current);
+
+      return () => {
+        if (observerRef.current) observer.unobserve(observerRef.current);
+      };
+    } catch (error) {
+      console.error("Failed to initialize IntersectionObserver:", error);
+    }
   }, [handleObserver]);
 
   return { observerRef, isFetchingNextPage };

--- a/src/hooks/useInfiniteScroll.ts
+++ b/src/hooks/useInfiniteScroll.ts
@@ -1,0 +1,34 @@
+import { useRef, useEffect, useCallback } from "react";
+
+type UseInfiniteScrollProps = {
+  fetchNextPage: () => void;
+  hasNextPage: boolean;
+  isFetchingNextPage: boolean;
+};
+
+export const useInfiniteScroll = ({ fetchNextPage, hasNextPage, isFetchingNextPage }: UseInfiniteScrollProps) => {
+  // 무한 스크롤을 감지할 ref
+  const observerRef = useRef<HTMLDivElement | null>(null);
+
+  const handleObserver = useCallback(
+    (entries: IntersectionObserverEntry[]) => {
+      const target = entries[0];
+      if (target.isIntersecting && hasNextPage && !isFetchingNextPage) {
+        fetchNextPage(); // 다음 데이터 요청
+      }
+    },
+    [fetchNextPage, hasNextPage, isFetchingNextPage],
+  );
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(handleObserver, { threshold: 1.0 });
+
+    if (observerRef.current) observer.observe(observerRef.current);
+
+    return () => {
+      if (observerRef.current) observer.unobserve(observerRef.current);
+    };
+  }, [handleObserver]);
+
+  return { observerRef, isFetchingNextPage };
+};


### PR DESCRIPTION
## Description

무한 스크롤을 커스텀 훅으로 분리했습니다. 

## Changes Made

- [x] 코드 리팩토링: 🔧
- 사용하실 땐 
```
import { useInfiniteScroll } from "@/hooks/useInfiniteScroll";

const { observerRef } = useInfiniteScroll({ fetchNextPage, hasNextPage, isFetchingNextPage });
```
이렇게 사용하시면 됩니다!

## Screenshots (선택)


## IssueNumber



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - 카드 목록 및 즐겨찾기 페이지의 무한 스크롤 기능이 커스텀 훅으로 개선되어, 스크롤이 끝에 도달할 때 자동으로 추가 콘텐츠가 원활하게 로드됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->