### PR TITLE
fix: sort button 재사용 컴포넌트

### DIFF
--- a/src/app/(common)/_home/_components/GatheringFilters.tsx
+++ b/src/app/(common)/_home/_components/GatheringFilters.tsx
@@ -3,11 +3,17 @@
 import { useState } from "react";
 import DateSelect from "@/components/Filtering/DateSelect";
 import LocationSelect from "@/components/Filtering/LocationSelect";
-import SortButton from "@/components/Filtering/SortButton";
+import SortButton from "@/components/SortButton";
 
 type GatheringFiltersProps = {
   onChange: (filters: { city?: string; district?: string; dateTime?: string; sortBy?: string }) => void;
 };
+
+const sortOption = [
+  { label: "마감 임박", value: "registrationEnd" },
+  { label: "참여 인원 순", value: "participantCount" },
+  { label: "모임 날짜 순", value: "dateTime" },
+] as const;
 
 export default function GatheringFilters({ onChange }: GatheringFiltersProps) {
   const [selectedCity, setSelectedCity] = useState<string>("");
@@ -53,6 +59,7 @@ export default function GatheringFilters({ onChange }: GatheringFiltersProps) {
           setSortType(sort);
           handleFilterChange();
         }}
+        sortOption={sortOption}
       />
     </div>
   );

--- a/src/components/SortButton.tsx
+++ b/src/components/SortButton.tsx
@@ -3,24 +3,20 @@
 import { useState } from "react";
 import SortIcon from "@/images/sort_icon.svg";
 
+type SortOption = { label: string; value: string };
+
 type SortButtonProps = {
   setSortType: (sortType: string) => void;
+  sortOption: SortOption[];
+  defaultSort?: string;
 };
 
-const sortOption = [
-  { label: "마감 임박", value: "registrationEnd" },
-  { label: "참여 인원 순", value: "participantCount" },
-  { label: "모임 날짜 순", value: "dateTime" },
-] as const;
-
-export default function SortButton({ setSortType }: SortButtonProps) {
+export default function SortButton({ setSortType, sortOption, defaultSort }: SortButtonProps) {
   const [isSortDropdownOpen, setSortDropdownOpen] = useState(false);
-  const [selectedSort, setSelectedSort] = useState<"registrationEnd" | "participantCount" | "dateTime">(
-    "registrationEnd",
-  );
+  const [selectedSort, setSelectedSort] = useState(defaultSort ?? sortOption[0]?.value);
 
   // 정렬 옵션 선택
-  const handleSort = (sortType: "registrationEnd" | "participantCount" | "dateTime") => {
+  const handleSort = (sortType: string) => {
     setSelectedSort(sortType);
     setSortDropdownOpen(false);
     setSortType(sortType); // 선택한 정렬 기준을 상위 컴포넌트에 전달
@@ -31,17 +27,13 @@ export default function SortButton({ setSortType }: SortButtonProps) {
       {/* 정렬 버튼 */}
       <button
         onClick={() => setSortDropdownOpen(!isSortDropdownOpen)}
-        className="mb-2 flex cursor-pointer rounded-xl border bg-gray-50 p-2 text-sm font-medium"
+        className="mb-2 flex cursor-pointer items-center rounded-xl border bg-gray-50 p-2 text-sm font-medium"
       >
         <div className="mr-1">
           <SortIcon />
         </div>
         <span className="hidden md:block">
-          {selectedSort === "registrationEnd"
-            ? "마감 임박"
-            : selectedSort === "participantCount"
-              ? "참여 인원 순"
-              : "모임 날짜 순"}
+          {sortOption.find((option) => option.value === selectedSort)?.label || "정렬"}
         </span>
       </button>
 

--- a/src/components/SortButton.tsx
+++ b/src/components/SortButton.tsx
@@ -7,7 +7,7 @@ type SortOption = { label: string; value: string };
 
 type SortButtonProps = {
   setSortType: (sortType: string) => void;
-  sortOption: SortOption[];
+  sortOption: readonly SortOption[];
   defaultSort?: string;
 };
 


### PR DESCRIPTION
## Description

sort button 요소를 props로 받도록하여 재사용 가능하게 코드를 수정하였습니다. 

## Changes Made

[변경사항 리스트를 적습니다.]

- [x] 기능 추가: ✅
- [x] 코드 리팩토링: 🔧
- 사용할 곳에서
``` tsx
const sortOption = [
  { label: "마감 임박", value: "registrationEnd" },
  { label: "참여 인원 순", value: "participantCount" },
  { label: "모임 날짜 순", value: "dateTime" },
] as const;

<SortButton
    setSortType={(sort) => { setSortType(sort); handleFilterChange(); }}
    sortOption={sortOption}
/>
```
이런식으로 정렬하고 싶은 항목 배열을 입력해주시고,  sortOption={sortOption}으로 props 전달하여 사용하면 됩니다!
타입 안정성 향상을 위해 sortOption을 선언할 때 as const를 사용했습니다.

## Screenshots (선택)


## IssueNumber

[#이슈번호]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- Gathering 필터의 정렬 기능이 개선되어, 사용자가 다양한 정렬 기준 중에서 더욱 직관적으로 선택하고 결과를 확인할 수 있습니다.
- **리팩토링**
	- 정렬 관련 인터페이스가 재구성되어, 기본 정렬 기준과 동적 옵션 표시에 따른 사용자 경험이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->