### PR TITLE
마이페이지 - 내가 만든 모임 구현

### DIFF
--- a/src/app/(common)/mypage/_components/MyCreatedGatherings.tsx
+++ b/src/app/(common)/mypage/_components/MyCreatedGatherings.tsx
@@ -2,10 +2,13 @@ import { useGetMyCreatedGatherings } from "@/app/(common)/mypage/_hooks/useGetCr
 import ListItem from "@/components/ListItem";
 import Spinner from "@/components/Spinner";
 import { useInfiniteScroll } from "@/hooks/useInfiniteScroll";
+import { useUserStore } from "@/stores/useUserStore";
 import Image from "next/image";
 
 export default function MyCreatedGatherings() {
-  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading, error } = useGetMyCreatedGatherings(1343);
+  // TODO: 회원정보 불러오기가 tanstack query로 바뀌면 바꿀 것
+  const id = useUserStore((state) => state.user?.id) as number;
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading, error } = useGetMyCreatedGatherings(id);
   const allGatherings = data?.pages.flatMap((page) => page.data) || [];
   const { observerRef } = useInfiniteScroll({
     hasNextPage,

--- a/src/app/(common)/mypage/_components/MyCreatedGatherings.tsx
+++ b/src/app/(common)/mypage/_components/MyCreatedGatherings.tsx
@@ -1,0 +1,73 @@
+import { useGetMyCreatedGatherings } from "@/app/(common)/mypage/_hooks/useGetCreatedGathering";
+import ListItem from "@/components/ListItem";
+import Spinner from "@/components/Spinner";
+import { useInfiniteScroll } from "@/hooks/useInfiniteScroll";
+import Image from "next/image";
+
+export default function MyCreatedGatherings() {
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading, error } = useGetMyCreatedGatherings(1343);
+  const allGatherings = data?.pages.flatMap((page) => page.data) || [];
+  const { observerRef } = useInfiniteScroll({
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage,
+  });
+
+  if (isLoading)
+    return (
+      <div className="flex flex-1 items-center justify-center">
+        <Spinner />
+      </div>
+    );
+  if (error)
+    return (
+      <div className="flex flex-1 items-center justify-center">
+        <p>목록 조회 중 에러가 발생했습니다.</p>
+      </div>
+    );
+  return (
+    <>
+      {allGatherings.length ? (
+        <>
+          <div className="w-full">
+            <div className="flex-1 divide-y-2 divide-dashed">
+              {allGatherings.map((gathering) => (
+                <div className="relative py-6" key={gathering.id}>
+                  <ListItem
+                    CardImage={
+                      <Image
+                        src={gathering.image}
+                        alt="모임 이미지"
+                        width={280}
+                        height={156}
+                        className="h-[156px] w-full rounded-3xl md:max-w-[280px]"
+                      />
+                    }
+                    className="justify-between"
+                  >
+                    <div className="flex flex-col gap-2.5">
+                      <div className="flex flex-col gap-1">
+                        <ListItem.Title title={gathering.name} subtitle={gathering.location} />
+                        <ListItem.SubInfo
+                          date={gathering.dateTime}
+                          participantCount={gathering.participantCount}
+                          capacity={gathering.capacity}
+                        />
+                      </div>
+                    </div>
+                  </ListItem>
+                </div>
+              ))}
+            </div>
+            <div ref={observerRef} className="h-10" />
+            {isFetchingNextPage && <div className="text-center text-sm text-gray-500">더 불러오는 중...</div>}
+          </div>
+        </>
+      ) : (
+        <div className="flex flex-1 items-center justify-center">
+          <p>아직 만든 모임이 없어요</p>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/app/(common)/mypage/_components/MypageContent.tsx
+++ b/src/app/(common)/mypage/_components/MypageContent.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import MyCreatedGatherings from "@/app/(common)/mypage/_components/MyCreatedGatherings";
 import MyGatherings from "@/app/(common)/mypage/_components/MyGatherings";
 import MyReviews from "@/app/(common)/mypage/_components/MyReviews";
 import ReviewableGatherings from "@/app/(common)/mypage/_components/ReviewableGatherings";
@@ -42,6 +43,7 @@ export default function MypageContent() {
         {selectedTab === "나의 모임" && <MyGatherings />}
         {selectedTab === "나의 리뷰" && selectedCategory === "작성 가능한 리뷰" && <ReviewableGatherings />}
         {selectedTab === "나의 리뷰" && selectedCategory === "작성한 리뷰" && <MyReviews />}
+        {selectedTab === "내가 만든 모임" && <MyCreatedGatherings />}
       </div>
     </div>
   );

--- a/src/app/(common)/mypage/_hooks/useGetCreatedGathering.ts
+++ b/src/app/(common)/mypage/_hooks/useGetCreatedGathering.ts
@@ -1,0 +1,31 @@
+import axiosInstance from "@/lib/axiosInstance";
+import { CardData } from "@/stores/useGatheringStore";
+import { useInfiniteQuery } from "@tanstack/react-query";
+
+// 공통 데이터 가져오기 함수 (sortBy와 sortOrder는 고정)
+const fetchMyCreatedGatherings = async ({ pageParam = 0, userId }: { pageParam: number; userId: number }) => {
+  const response = await axiosInstance.get<CardData[]>("gatherings", {
+    params: {
+      limit: 5,
+      offset: pageParam,
+      sortBy: "dateTime",
+      sortOrder: "desc",
+      createdBy: userId,
+    },
+  });
+
+  return {
+    data: response.data,
+    nextOffset: response.data.length === 5 ? pageParam + 5 : null,
+  };
+};
+
+export const useGetMyCreatedGatherings = (userId: number) => {
+  return useInfiniteQuery({
+    queryKey: ["mypage", "gatherings", "created"],
+    queryFn: ({ pageParam }) => fetchMyCreatedGatherings({ pageParam, userId }),
+    initialPageParam: 0,
+    getNextPageParam: (lastPage) => lastPage.nextOffset,
+    staleTime: 60000,
+  });
+};

--- a/src/app/(common)/mypage/_hooks/useGetCreatedGathering.ts
+++ b/src/app/(common)/mypage/_hooks/useGetCreatedGathering.ts
@@ -2,7 +2,6 @@ import axiosInstance from "@/lib/axiosInstance";
 import { CardData } from "@/stores/useGatheringStore";
 import { useInfiniteQuery } from "@tanstack/react-query";
 
-// 공통 데이터 가져오기 함수 (sortBy와 sortOrder는 고정)
 const fetchMyCreatedGatherings = async ({ pageParam = 0, userId }: { pageParam: number; userId: number }) => {
   const response = await axiosInstance.get<CardData[]>("gatherings", {
     params: {


### PR DESCRIPTION
## Description

마이페이지 - 내가 만든 모임 페이지를 구현했습니다.

## Changes Made

[변경사항 리스트를 적습니다.]

- [x] 기능 추가: ✅

- 내가 만든 모임 불러오기를 구현했습니다(무한 스크롤, 모임일 내림차순)

## Screenshots (선택)
<img width="600" alt="스크린샷 2025-02-21 오후 3 02 33" src="https://github.com/user-attachments/assets/31dbab15-8a45-4913-b094-7fb65859c0c8" />
<img width="600" alt="스크린샷 2025-02-21 오후 3 02 52" src="https://github.com/user-attachments/assets/26d42310-199d-4a1b-ad8f-9db23bd7e757" />


## IssueNumber

#115


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - "내가 만든 모임" 탭이 추가되어, 사용자가 자신이 생성한 모임을 한눈에 확인할 수 있습니다.
  - 무한 스크롤 기능을 적용해 스크롤 시 추가 모임이 자동으로 로드됩니다.
  - 데이터 로딩 중에는 스피너를, 오류 발생 시에는 명확한 오류 메시지를 제공하여 사용자 경험을 향상시켰습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->