### PR TITLE
fix: 모집 정원 5명에서 멈추는 버그 수정

### DIFF
--- a/src/app/(common)/gathering/[id]/page.tsx
+++ b/src/app/(common)/gathering/[id]/page.tsx
@@ -32,7 +32,7 @@ export default async function Page({
     queryClient.prefetchQuery({
       queryKey: ["participants", gatheringId],
       queryFn: async () => {
-        const { data } = await axiosInstance.get(`/gatherings/${gatheringId}/participants`);
+        const { data } = await axiosInstance.get(`/gatherings/${gatheringId}/participants?limit=100`);
         return data;
       },
     }),

--- a/src/app/(common)/gathering/_utils/apis.ts
+++ b/src/app/(common)/gathering/_utils/apis.ts
@@ -12,6 +12,6 @@ export const fetchReviews = async (query?: ReviewQuery): Promise<ReviewsResponse
 };
 
 export const getParticipants = async (gatheringId: string): Promise<GatheringParticipantType[]> => {
-  const { data } = await axiosInstance(`/gatherings/${gatheringId}/participants`);
+  const { data } = await axiosInstance.get(`/gatherings/${gatheringId}/participants?limit=100`);
   return data;
 };


### PR DESCRIPTION
## Description
상세페이지 모집 정원이 5명 이상일 시 나타나는 버그를 수정하였습니다.

## Changes Made

- [x] 버그 수정: 🐛
- gatherings/id/participants 해당 앤드포인트로 참여자 데이터를 가져오는데 해당 앤드포인트 limit가 5여서 발생한 버그
- limit를 일단 임시로 지정하였습니다

## Screenshots (선택)
<img width="486" alt="스크린샷 2025-02-28 오전 9 47 29" src="https://github.com/user-attachments/assets/ad0edba9-910d-409d-b454-cf49e770fc32" />


## IssueNumber



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- 그라더링 페이지에서 참가자 데이터를 불러올 때 한 번에 최대 100명만 로드되도록 개선했습니다. 이로 인해 불필요한 데이터 로딩이 줄어들어 페이지 응답성과 안정성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->