### PR TITLE
마이페이지 - InactiveLayer 수정 및 ListItem시간 수정

### DIFF
--- a/src/app/(common)/mypage/_hooks/useReviewForm.ts
+++ b/src/app/(common)/mypage/_hooks/useReviewForm.ts
@@ -19,7 +19,7 @@ export const useReviewForm = ({ gatheringId, onClose }: UseReviewFormProps) => {
     watch,
     reset,
   } = useForm<ReviewFormValues>({
-    mode: "onChange",
+    mode: "onBlur",
     defaultValues: {
       score: 0,
       comment: "",

--- a/src/components/InactiveLayer.tsx
+++ b/src/components/InactiveLayer.tsx
@@ -7,7 +7,7 @@ type InactiveLayerProps = {
 };
 export default function InactiveLayer({ onClick, message, isCompleted }: InactiveLayerProps) {
   return (
-    <div className="absolute flex h-full w-full flex-col-reverse items-center justify-center gap-6 rounded-xl bg-black bg-opacity-80 md:flex-col md:rounded-3xl">
+    <div className="absolute z-10 flex h-full w-full flex-col-reverse items-center justify-center gap-6 bg-black bg-opacity-80 md:flex-col">
       {!isCompleted && (
         <LikeButton className="md:absolute md:right-6 md:top-6 md:ml-auto" isClosed onClick={onClick} isLiked={false} />
       )}

--- a/src/components/ListItem.tsx
+++ b/src/components/ListItem.tsx
@@ -6,8 +6,6 @@ import Check from "@/images/check.svg";
 import { PropsWithChildren } from "react";
 import InactiveLayer from "@/components/InactiveLayer";
 import dayjs from "dayjs";
-import utc from "dayjs/plugin/utc";
-dayjs.extend(utc);
 
 type ListItemProps = {
   CardImage?: React.ReactNode;
@@ -104,8 +102,8 @@ type SubInfoProps = {
   capacity: number;
 };
 ListItem.SubInfo = ({ date, participantCount, capacity }: SubInfoProps) => {
-  const formatDate = dayjs.utc(date).format("M월 D일");
-  const formatTime = dayjs.utc(date).format("HH:mm");
+  const formatDate = dayjs(date).format("M월 D일");
+  const formatTime = dayjs(date).format("HH:mm");
   return (
     <div className="flex items-center gap-3 text-sm text-gray-700">
       <div>{`${formatDate} · ${formatTime}`}</div>

--- a/src/components/ListItem.tsx
+++ b/src/components/ListItem.tsx
@@ -26,7 +26,9 @@ export default function ListItem({
   className,
 }: PropsWithChildren<ListItemProps>) {
   return (
-    <div className={`relative flex w-full flex-col items-stretch gap-4 border-gray-300 md:max-w-none md:flex-row`}>
+    <div
+      className={`relative ${canceledAt && handleCancel && "overflow-hidden rounded-xl md:rounded-3xl"} flex w-full flex-col items-stretch gap-4 border-gray-300 md:max-w-none md:flex-row`}
+    >
       {canceledAt && handleCancel && (
         <InactiveLayer isCompleted={isCompleted} onClick={handleCancel} message="모집 취소된 모임이에요" />
       )}


### PR DESCRIPTION
## Description

InactiveLayer를 수정하고 해당 사항 적용했습니다.

## Changes Made

[변경사항 리스트를 적습니다.]

- [x] 코드 리팩토링: 🔧

- InactiveLayer에 z-index 설정, rounded삭제
  - 사용하는 측에서 overflow-hidden및 rounded설정
- ListItem의 시간대를 원상복귀 시켰습니다.
## Screenshots (선택)

## IssueNumber

#156


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **스타일**
	- 비활성 레이어 컴포넌트의 디자인을 개선하여 기존 둥근 모서리 효과 대신 새로운 시각적 계층 효과를 적용하였습니다.
	- 리스트 항목에 특정 상태에 따라 조건부 스타일이 추가되어 다양한 표시 상황에서 더욱 일관된 외관을 제공합니다.
- **버그 수정**
	- 날짜 포맷팅을 UTC에서 로컬 시간대로 변경하여 보다 정확한 시간 정보를 제공합니다.
- **기타 변경 사항**
	- 리뷰 폼의 유효성 검사 모드를 변경하여 입력 필드가 포커스를 잃을 때 유효성 검사가 수행되도록 조정하였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->