### PR TITLE
fix:회원가입시 유효성 검사 및 error발생시 helper text 노출되도록 수정

### DIFF
--- a/public/images/checkbox_checked.svg
+++ b/public/images/checkbox_checked.svg
@@ -1,4 +1,4 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
 <rect x="3" y="3" width="18" height="18" rx="6" fill="white"/>
-<path d="M7 11.625L10.1098 14.7348C10.2563 14.8813 10.4937 14.8813 10.6402 14.7348L16.375 9" stroke="#EA580C" stroke-width="2" stroke-linecap="round"/>
+<path d="M7 11.625L10.1098 14.7348C10.2563 14.8813 10.4937 14.8813 10.6402 14.7348L16.375 9" stroke="#62a3f9" stroke-width="2" stroke-linecap="round"/>
 </svg>

--- a/src/app/(auth)/sign-up/page.tsx
+++ b/src/app/(auth)/sign-up/page.tsx
@@ -81,6 +81,7 @@ export default function SignUp() {
         setError("email", { type: "manual", message: "중복된 이메일입니다." });
       }
     }
+    setLoginProgress(false);
   };
 
   const postSignUp = async (data: FormValues) => {

--- a/src/app/(auth)/sign-up/page.tsx
+++ b/src/app/(auth)/sign-up/page.tsx
@@ -71,24 +71,21 @@ export default function SignUp() {
     }
     if (InvalidError) return;
     setLoginProgress(true);
-    const result = await postSignUp({ name, email, companyName, password });
-    if (result.message === "사용자 생성 성공") {
-      setIsModal(true);
-    } else {
-      if (result.message === "Database error") {
+    try {
+      const result = await postSignUp({ name, email, companyName, password });
+      if (result.message === "사용자 생성 성공") {
+        setIsModal(true);
+      }
+    } catch (error) {
+      if (axios.isAxiosError(error) && error.response?.status === 400) {
         setError("email", { type: "manual", message: "중복된 이메일입니다." });
       }
-      setLoginProgress(false);
     }
   };
 
   const postSignUp = async (data: FormValues) => {
-    try {
-      const response = await axios.post(`${process.env.NEXT_PUBLIC_API_BASE_URL}auths/signup`, data);
-      return response.data;
-    } catch (error) {
-      console.error("회원가입에 실패 하였습니다.", error);
-    }
+    const response = await axios.post(`${process.env.NEXT_PUBLIC_API_BASE_URL}auths/signup`, data);
+    return response.data;
   };
 
   useEffect(() => {

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -97,9 +97,13 @@ export default function Header() {
           </Link>
           <Link href={"/favorites"} className={`${getLinkClass("/favorites")} gap-1`}>
             찜한 모임{" "}
-            <b className="rounded-full bg-black px-2 text-xs font-semibold text-white">
-              {favoritesCount > 0 && `${favoritesCount}`}
-            </b>
+            {favoritesCount !== 0 ? (
+              <b className="rounded-full bg-black px-2 text-xs font-semibold text-white">
+                {favoritesCount > 0 && `${favoritesCount}`}
+              </b>
+            ) : (
+              ""
+            )}
           </Link>
           <Link href={"/reviews"} className={getLinkClass("/reviews")}>
             모든 리뷰


### PR DESCRIPTION
## Description

header 찜한 모임이 없을 경우 찜한 갯수가 노출되지 않더라도 영역을 잡아먹던 문제를 해결했습니다.
회원가입시 동일한 이메일로 진행할 경우 helper text 노출하도록 코드를 수정했습니다.
모임만들기 checkBoxIcon 메인컬러로 수정했습니다.

## Changes Made

[변경사항 리스트를 적습니다.]

- [x] 코드 리팩토링: 🔧

## Screenshots (선택)

[UI 변경사항이 있다면 스크린샷을 추가해주세요.]

## IssueNumber

[#이슈번호]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
	- 회원가입 과정에서 이메일 중복 시 적절한 안내 메시지가 표시되어, 오류 발생 시 진행 상태가 정상적으로 업데이트됩니다.
	- 헤더의 즐겨찾기 수 표시를 개선하여, 즐겨찾기가 없을 경우 불필요한 강조가 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->