### PR TITLE
body 기본 color 삭제

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -15,7 +15,6 @@
 }
 
 body {
-  color: var(--foreground);
   background: var(--background);
   font-family: Arial, Helvetica, sans-serif;
 }


### PR DESCRIPTION
## Description

body 기본 color 삭제했습니다.

## Changes Made

[변경사항 리스트를 적습니다.]

- global.css에 설정된 기본 색상을 지웠습니다.

## Screenshots (선택)

## IssueNumber

#192 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- 어플리케이션 글로벌 스타일 업데이트: 기존에 본문의 텍스트 색상을 강제로 지정하던 설정이 제거되어, 이제 텍스트 색상이 사용 중인 브라우저 기본값이나 상속받은 스타일에 따라 표시됩니다. 배경색과 글꼴은 변경되지 않아 전체 디자인의 일관성은 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->