### PR TITLE
fix: 무한스크롤 버그 수정

### DIFF
--- a/src/app/(common)/gathering/[id]/page.tsx
+++ b/src/app/(common)/gathering/[id]/page.tsx
@@ -53,13 +53,13 @@ export default async function Page({
   return (
     <div className="mb-[84px] flex w-full flex-col gap-6">
       <HydrationBoundary state={dehydratedState}>
-        <Gathering gathering={gathering} />
+        <Gathering gatheringId={gatheringId} gathering={gathering} />
         <ErrorBoundary>
           <Reviews gatheringId={gatheringId} reviewQuery={reviewParams} />
         </ErrorBoundary>
       </HydrationBoundary>
 
-      <FloatingBar gatheringId={gatheringId} hostUserId={gathering.createdBy} />
+      <FloatingBar gatheringId={gatheringId} gathering={gathering} hostUserId={gathering.createdBy} />
     </div>
   );
 }

--- a/src/app/(common)/gathering/_components/Gathering.tsx
+++ b/src/app/(common)/gathering/_components/Gathering.tsx
@@ -3,15 +3,16 @@ import Thumbnail from "@/app/(common)/gathering/_components/Thumbnail";
 import type { GatheringType } from "@/app/(common)/gathering/types";
 
 type GatheringProps = {
+  gatheringId: string;
   gathering: GatheringType;
   profileImages?: (string | null)[];
 };
 
-export default function Gathering({ gathering, profileImages }: GatheringProps) {
+export default function Gathering({ gatheringId, gathering, profileImages }: GatheringProps) {
   return (
     <div className="flex flex-col items-center gap-4 pt-6 md:flex-row lg:pt-10">
       <Thumbnail name={gathering.name} imageUrl={gathering.image} registrationEnd={gathering.registrationEnd} />
-      <GatheringInfo gatheringId={`${gathering.id}`} gathering={gathering} profileImages={profileImages} />
+      <GatheringInfo gatheringId={gatheringId} gathering={gathering} profileImages={profileImages} />
     </div>
   );
 }

--- a/src/app/(common)/gathering/_hooks/useJoin.ts
+++ b/src/app/(common)/gathering/_hooks/useJoin.ts
@@ -1,9 +1,15 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { AxiosError } from "axios";
 import axiosInstance from "@/lib/axiosInstance";
 
 const joinGathering = async (gatheringId: string) => {
-  const { data } = await axiosInstance.post(`/gatherings/${gatheringId}/join`);
-  return data;
+  try {
+    const { data } = await axiosInstance.post(`/gatherings/${gatheringId}/join`);
+    return data;
+  } catch (e) {
+    const error = e as AxiosError<{ code: string; message: string }>;
+    throw new Error(error.response?.data.message);
+  }
 };
 
 export const useJoin = (gatheringId: string) => {


### PR DESCRIPTION
## Description

처음에 무한 스크롤 작동되지 않다가 새로고침 후 정상 작동하는 문제를 수정했습니다.

## Changes Made

- [x] 버그 수정: 🐛
- ref callback으로 수정
useEffect 실행시 ref는 null이기 때문에 발생한 문제
ref callback을 사용해서 렌더링 이후 시점에 실행되도록 수정
[reference](https://velog.io/@cnsrn1874/%EB%B2%88%EC%97%AD-callback-refs-%EC%82%AC%EC%9A%A9%EC%9C%BC%EB%A1%9C-useEffect-%EB%B0%A9%EC%A7%80%ED%95%98%EA%B8%B0)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 모임 관련 인터페이스에 모임 식별자 정보를 직접 전달하여 일관된 데이터 처리가 가능해졌습니다.
	- 등록 마감 조건에 따른 버튼의 로딩 및 비활성화 상태가 개선되어 보다 명확한 사용자 피드백을 제공합니다.
	- 모임 참여 요청 시 개선된 에러 처리를 통해 보다 명확한 오류 안내가 이루어집니다.

- **리팩토링**
	- 무한 스크롤 기능의 요소 감지 로직이 개선되어 인터랙션 처리의 안정성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->