### PR TITLE
마이페이지에서 모임 항목을 누르면 모임 상세 페이지로 이동

### DIFF
--- a/src/app/(common)/mypage/_components/MyCreatedGatherings.tsx
+++ b/src/app/(common)/mypage/_components/MyCreatedGatherings.tsx
@@ -4,6 +4,7 @@ import { fetchMyCreatedGatherings } from "@/app/(common)/mypage/utils/apis";
 import ListItem from "@/components/ListItem";
 import Image from "next/image";
 import DEFAULT_IMAGE from "@/images/default_image.png";
+import Link from "next/link";
 export default function MyCreatedGatherings() {
   const { data: userData } = useGetUserInfo();
 
@@ -17,29 +18,31 @@ export default function MyCreatedGatherings() {
         emptyMessage={"아직 만든 모임이 없어요"}
         render={(gathering) => (
           <div className="relative py-6" key={gathering.id}>
-            <ListItem
-              CardImage={
-                <Image
-                  src={gathering.image || DEFAULT_IMAGE}
-                  alt={`${gathering.name} 이미지`}
-                  width={280}
-                  height={156}
-                  className="h-[156px] w-full rounded-3xl md:max-w-[280px]"
-                />
-              }
-              className="justify-between"
-            >
-              <div className="flex flex-col gap-2.5">
-                <div className="flex flex-col gap-1">
-                  <ListItem.Title title={gathering.name} subtitle={gathering.location} />
-                  <ListItem.SubInfo
-                    date={gathering.dateTime}
-                    participantCount={gathering.participantCount}
-                    capacity={gathering.capacity}
+            <Link href={`/gathering/${gathering.id}`}>
+              <ListItem
+                CardImage={
+                  <Image
+                    src={gathering.image || DEFAULT_IMAGE}
+                    alt={`${gathering.name} 이미지`}
+                    width={280}
+                    height={156}
+                    className="h-[156px] w-full rounded-3xl md:max-w-[280px]"
                   />
+                }
+                className="justify-between"
+              >
+                <div className="flex flex-col gap-2.5">
+                  <div className="flex flex-col gap-1">
+                    <ListItem.Title title={gathering.name} subtitle={gathering.location} />
+                    <ListItem.SubInfo
+                      date={gathering.dateTime}
+                      participantCount={gathering.participantCount}
+                      capacity={gathering.capacity}
+                    />
+                  </div>
                 </div>
-              </div>
-            </ListItem>
+              </ListItem>
+            </Link>
           </div>
         )}
       />

--- a/src/app/(common)/mypage/_components/MyGatherings.tsx
+++ b/src/app/(common)/mypage/_components/MyGatherings.tsx
@@ -7,6 +7,7 @@ import MypageList from "@/app/(common)/mypage/_components/MypageList";
 import { fetchMyGatherings } from "@/app/(common)/mypage/utils/apis";
 import DEFAULT_IMAGE from "@/images/default_image.png";
 import { ReviewModal } from "@/app/(common)/mypage/_components/ReviewModal";
+import Link from "next/link";
 
 // 이용 예정 => 모임 참여 신청했고 isCompleted가 false인 경우
 // 이용 완료 => 모임 참여 신청했고 isCompleted가 true인 경우
@@ -47,49 +48,61 @@ export default function MyGatherings() {
         emptyMessage={"신청한 모임이 아직 없어요"}
         render={(gathering) => (
           <div className="relative py-6" key={gathering.id}>
-            <ListItem
-              CardImage={
-                <Image
-                  src={gathering.image || DEFAULT_IMAGE}
-                  alt={`${gathering.name} 이미지`}
-                  width={280}
-                  height={156}
-                  className="h-[156px] w-full rounded-3xl md:max-w-[280px]"
-                />
-              }
-              isCompleted={gathering.isCompleted}
-              canceledAt={gathering.canceledAt}
-              handleCancel={() => mutation.mutate(gathering.id)}
-              className="justify-between"
-            >
-              <div className="flex flex-col gap-2.5">
-                <ListItem.Status isCompleted={gathering.isCompleted} participantCount={gathering.participantCount} />
-                <div className="flex flex-col gap-1">
-                  <ListItem.Title title={gathering.name} subtitle={gathering.location} />
-                  <ListItem.SubInfo
-                    date={gathering.dateTime}
-                    participantCount={gathering.participantCount}
-                    capacity={gathering.capacity}
+            <Link href={`/gathering/${gathering.id}`}>
+              <ListItem
+                CardImage={
+                  <Image
+                    src={gathering.image || DEFAULT_IMAGE}
+                    alt={`${gathering.name} 이미지`}
+                    width={280}
+                    height={156}
+                    className="h-[156px] w-full rounded-3xl md:max-w-[280px]"
                   />
+                }
+                isCompleted={gathering.isCompleted}
+                canceledAt={gathering.canceledAt}
+                handleCancel={() => mutation.mutate(gathering.id)}
+                className="justify-between"
+              >
+                <div className="flex flex-col gap-2.5">
+                  <ListItem.Status isCompleted={gathering.isCompleted} participantCount={gathering.participantCount} />
+                  <div className="flex flex-col gap-1">
+                    <ListItem.Title title={gathering.name} subtitle={gathering.location} />
+                    <ListItem.SubInfo
+                      date={gathering.dateTime}
+                      participantCount={gathering.participantCount}
+                      capacity={gathering.capacity}
+                    />
+                  </div>
                 </div>
-              </div>
-              {gathering.isReviewed ? (
-                <Button className={"mt-[18px] w-full max-w-[120px]"} size={"sm"} styleType={"solid"} disabled>
-                  리뷰 작성 완료
-                </Button>
-              ) : (
-                <Button
-                  onClick={gathering.isCompleted ? () => handleOpen(gathering.id) : () => mutation.mutate(gathering.id)}
-                  className={"mt-[18px] w-full max-w-[120px]"}
-                  size={"sm"}
-                  styleType={gathering.isCompleted ? "solid" : "outline"}
-                  disabled={!!gathering.canceledAt}
-                >
-                  {/*모임이 끝났으면 리뷰 작성 / 아니면 예약 취소 */}
-                  {gathering.isCompleted ? "리뷰 작성하기" : "예약 취소하기"}
-                </Button>
-              )}
-            </ListItem>
+                {gathering.isReviewed ? (
+                  <Button className={"mt-[18px] w-full max-w-[120px]"} size={"sm"} styleType={"solid"} disabled>
+                    리뷰 작성 완료
+                  </Button>
+                ) : (
+                  <Button
+                    onClick={
+                      gathering.isCompleted
+                        ? (e) => {
+                            e.preventDefault();
+                            handleOpen(gathering.id);
+                          }
+                        : (e) => {
+                            e.preventDefault();
+                            mutation.mutate(gathering.id);
+                          }
+                    }
+                    className={"mt-[18px] w-full max-w-[120px]"}
+                    size={"sm"}
+                    styleType={gathering.isCompleted ? "solid" : "outline"}
+                    disabled={!!gathering.canceledAt}
+                  >
+                    {/*모임이 끝났으면 리뷰 작성 / 아니면 예약 취소 */}
+                    {gathering.isCompleted ? "리뷰 작성하기" : "예약 취소하기"}
+                  </Button>
+                )}
+              </ListItem>
+            </Link>
           </div>
         )}
       />

--- a/src/app/(common)/mypage/_components/MyReviews.tsx
+++ b/src/app/(common)/mypage/_components/MyReviews.tsx
@@ -5,6 +5,7 @@ import Score from "@/components/Score";
 import Image from "next/image";
 import DEFAULT_IMAGE from "@/images/default_image.png";
 import { fetchMyReviews } from "@/app/(common)/mypage/utils/apis";
+import Link from "next/link";
 const GatheringType = {
   OFFICE_STRETCHING: "달램핏 오피스 스트레칭",
   MINDFULNESS: "달램핏 마인드풀니스",
@@ -24,30 +25,32 @@ export default function MyReviews() {
         }}
         emptyMessage={"아직 작성 가능한 리뷰가 없어요"}
         render={(review) => (
-          <ListItem
-            CardImage={
-              <Image
-                src={review.Gathering.image || DEFAULT_IMAGE}
-                alt={`${review.Gathering.name} 이미지`}
-                width={280}
-                height={156}
-                className="h-[156px] w-full rounded-3xl md:max-w-[280px]"
-              />
-            }
-            key={review.id}
-            className="w-full justify-between"
-          >
-            <div className="flex h-full w-full flex-col gap-2 border-b-2 border-dashed pb-6">
-              <div className="flex flex-col gap-2.5">
-                <Score score={review.score} />
-                <ListItem.Body>{review.comment}</ListItem.Body>
-                <ListItem.ServiceInfo>
-                  {GatheringType[review.Gathering.type]} 이용 · {review.Gathering.location}
-                </ListItem.ServiceInfo>
+          <Link href={`/gathering/${review.Gathering.id}`}>
+            <ListItem
+              CardImage={
+                <Image
+                  src={review.Gathering.image || DEFAULT_IMAGE}
+                  alt={`${review.Gathering.name} 이미지`}
+                  width={280}
+                  height={156}
+                  className="h-[156px] w-full rounded-3xl md:max-w-[280px]"
+                />
+              }
+              key={review.id}
+              className="w-full justify-between"
+            >
+              <div className="flex h-full w-full flex-col gap-2 border-b-2 border-dashed pb-6">
+                <div className="flex flex-col gap-2.5">
+                  <Score score={review.score} />
+                  <ListItem.Body>{review.comment}</ListItem.Body>
+                  <ListItem.ServiceInfo>
+                    {GatheringType[review.Gathering.type]} 이용 · {review.Gathering.location}
+                  </ListItem.ServiceInfo>
+                </div>
+                <ListItem.MetaInfo secondary={review.createdAt} />
               </div>
-              <ListItem.MetaInfo secondary={review.createdAt} />
-            </div>
-          </ListItem>
+            </ListItem>
+          </Link>
         )}
       />
     </>

--- a/src/app/(common)/mypage/_components/ReviewableGatherings.tsx
+++ b/src/app/(common)/mypage/_components/ReviewableGatherings.tsx
@@ -9,6 +9,7 @@ import ReviewModal from "@/app/(common)/mypage/_components/ReviewModal/ReviewMod
 import MypageList from "@/app/(common)/mypage/_components/MypageList";
 import { fetchMyGatherings } from "@/app/(common)/mypage/utils/apis";
 import DEFAULT_IMAGE from "@/images/default_image.png";
+import Link from "next/link";
 
 export default function ReviewableGatherings() {
   const [isModalOpen, setModalOpen] = useState(false);
@@ -35,41 +36,46 @@ export default function ReviewableGatherings() {
         render={(gathering) =>
           !gathering.canceledAt && (
             <div className="relative py-6" key={gathering.id}>
-              <ListItem
-                CardImage={
-                  <Image
-                    src={gathering.image || DEFAULT_IMAGE}
-                    alt={`${gathering.name} 이미지`}
-                    width={280}
-                    height={156}
-                    className="h-[156px] w-full rounded-3xl md:max-w-[280px]"
-                  />
-                }
-                isCompleted={gathering.isCompleted}
-                canceledAt={gathering.canceledAt}
-                handleCancel={() => mutation.mutate(gathering.id)}
-                className="justify-between"
-              >
-                <div className="flex flex-col gap-2.5">
-                  <div className="flex flex-col gap-1">
-                    <ListItem.Title title={gathering.name} subtitle={gathering.location} />
-                    <ListItem.SubInfo
-                      date={gathering.dateTime}
-                      participantCount={gathering.participantCount}
-                      capacity={gathering.capacity}
+              <Link href={`/gathering/${gathering.id}`}>
+                <ListItem
+                  CardImage={
+                    <Image
+                      src={gathering.image || DEFAULT_IMAGE}
+                      alt={`${gathering.name} 이미지`}
+                      width={280}
+                      height={156}
+                      className="h-[156px] w-full rounded-3xl md:max-w-[280px]"
                     />
-                  </div>
-                </div>
-                <Button
-                  onClick={() => handleOpen(gathering.id)}
-                  className={"mt-[18px] w-full max-w-[120px]"}
-                  size={"sm"}
-                  styleType={"solid"}
-                  disabled={!!gathering.canceledAt}
+                  }
+                  isCompleted={gathering.isCompleted}
+                  canceledAt={gathering.canceledAt}
+                  handleCancel={() => mutation.mutate(gathering.id)}
+                  className="justify-between"
                 >
-                  리뷰 작성하기
-                </Button>
-              </ListItem>
+                  <div className="flex flex-col gap-2.5">
+                    <div className="flex flex-col gap-1">
+                      <ListItem.Title title={gathering.name} subtitle={gathering.location} />
+                      <ListItem.SubInfo
+                        date={gathering.dateTime}
+                        participantCount={gathering.participantCount}
+                        capacity={gathering.capacity}
+                      />
+                    </div>
+                  </div>
+                  <Button
+                    onClick={(e) => {
+                      e.preventDefault();
+                      handleOpen(gathering.id);
+                    }}
+                    className={"mt-[18px] w-full max-w-[120px]"}
+                    size={"sm"}
+                    styleType={"solid"}
+                    disabled={!!gathering.canceledAt}
+                  >
+                    리뷰 작성하기
+                  </Button>
+                </ListItem>
+              </Link>
             </div>
           )
         }


### PR DESCRIPTION
## Description

마이페이지에서 모임 항목을 누르면 모임 상세 페이지로 이동시키도록 구현했습니다.

## Changes Made

- [x] 기능 추가: ✅

- 마이페이지에서 각 모임 항목을 누르면 항목의 상세페이지로 이동합니다.

## Screenshots

## IssueNumber

#202


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 모임 및 리뷰 항목이 클릭 가능한 링크로 전환되어, 전체 항목 클릭 시 상세 페이지로 이동할 수 있도록 개선되었습니다.
  - 특정 버튼 클릭 시 기본 링크 동작을 방지해, 모달 창 등 부가 기능이 올바르게 작동하도록 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->