### PR TITLE
fix: 마이 페이지를 SuspenseQuery 변경 #202

### DIFF
--- a/src/app/(common)/mypage/_components/MypageContent.tsx
+++ b/src/app/(common)/mypage/_components/MypageContent.tsx
@@ -6,7 +6,10 @@ import MyReviews from "@/app/(common)/mypage/_components/MyReviews";
 import ReviewableGatherings from "@/app/(common)/mypage/_components/ReviewableGatherings";
 import useMypageTab from "@/app/(common)/mypage/_hooks/useMypageTab";
 import CategoryButton from "@/components/CategoryButton";
+import ErrorBoundary from "@/components/ErrorBoundary";
+import Spinner from "@/components/Spinner";
 import Tab from "@/components/Tab";
+import { Suspense } from "react";
 
 const TAB_ITEMS = ["나의 모임", "나의 리뷰", "내가 만든 모임"];
 const CATEGORIES = ["작성 가능한 리뷰", "작성한 리뷰"];
@@ -45,10 +48,20 @@ export default function MypageContent() {
       <div
         className={`flex flex-1 flex-col ${selectedCategory !== "작성한 리뷰" ? "divide-y-2 divide-dashed" : "gap-6"}`}
       >
-        {selectedTab === "나의 모임" && <MyGatherings />}
-        {selectedTab === "나의 리뷰" && selectedCategory === "작성 가능한 리뷰" && <ReviewableGatherings />}
-        {selectedTab === "나의 리뷰" && selectedCategory === "작성한 리뷰" && <MyReviews />}
-        {selectedTab === "내가 만든 모임" && <MyCreatedGatherings />}
+        <ErrorBoundary>
+          <Suspense
+            fallback={
+              <div className="flex flex-1 items-center justify-center">
+                <Spinner />
+              </div>
+            }
+          >
+            {selectedTab === "나의 모임" && <MyGatherings />}
+            {selectedTab === "나의 리뷰" && selectedCategory === "작성 가능한 리뷰" && <ReviewableGatherings />}
+            {selectedTab === "나의 리뷰" && selectedCategory === "작성한 리뷰" && <MyReviews />}
+            {selectedTab === "내가 만든 모임" && <MyCreatedGatherings />}
+          </Suspense>
+        </ErrorBoundary>
       </div>
     </div>
   );

--- a/src/app/(common)/mypage/_components/MypageList.tsx
+++ b/src/app/(common)/mypage/_components/MypageList.tsx
@@ -1,12 +1,11 @@
 import { MyGathering } from "@/app/(common)/mypage/types";
-import Spinner from "@/components/Spinner";
 import { GatheringType, ReviewResponse } from "@/types";
-import { useQuery, UseQueryOptions } from "@tanstack/react-query";
+import { useSuspenseQuery, UseSuspenseQueryOptions } from "@tanstack/react-query";
 
 type GatheringListProps<T extends MyGathering | ReviewResponse | GatheringType> = {
   render: (item: T) => React.ReactNode;
   emptyMessage: string;
-  queryOption: UseQueryOptions<T[], Error>;
+  queryOption: UseSuspenseQueryOptions<T[], Error>;
 };
 
 export default function MypageList<T extends MyGathering | ReviewResponse | GatheringType>({
@@ -14,15 +13,7 @@ export default function MypageList<T extends MyGathering | ReviewResponse | Gath
   emptyMessage,
   queryOption,
 }: GatheringListProps<T>) {
-  const { data, isLoading, error } = useQuery({ ...queryOption });
-
-  if (isLoading) {
-    return (
-      <div className="flex flex-1 items-center justify-center">
-        <Spinner />
-      </div>
-    );
-  }
+  const { data, error } = useSuspenseQuery({ ...queryOption });
 
   if (error) {
     return (
@@ -33,7 +24,7 @@ export default function MypageList<T extends MyGathering | ReviewResponse | Gath
   }
   return (
     <>
-      {data?.length ? (
+      {data.length ? (
         <>{data.map((gathering) => render(gathering))}</>
       ) : (
         <div className="flex flex-1 items-center justify-center">


### PR DESCRIPTION
## Description

마이페이지 쪽 SuspenseQuery이용하도록 변경했습니다.

## Changes Made

[변경사항 리스트를 적습니다.]

- [x] 코드 리팩토링: 🔧

- useQuery사용하던 부분을 useSuspenseQuery사용하도록 바꿨습니다.

## Screenshots (선택)


## IssueNumber

#202 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 페이지 내 탭 전환 시 발생할 수 있는 오류를 안정적으로 처리하고, 콘텐츠 로딩 중 스피너로 진행 상태를 안내하여 사용자 경험을 강화했습니다.
  - 데이터 로딩 프로세스가 간소화되어 콘텐츠가 보다 매끄럽게 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->