### PR TITLE
fix: 프로필 이미지 hover animation

### DIFF
--- a/src/app/(common)/gathering/_components/GatheredProfiles.tsx
+++ b/src/app/(common)/gathering/_components/GatheredProfiles.tsx
@@ -6,18 +6,41 @@ type GatheredProfilesProps = {
 
 export default function GatheredProfiles({ profileImages }: GatheredProfilesProps) {
   const count = profileImages.length;
+
+  const rows = [];
+  for (let i = 0; i < profileImages.length; i += 4) {
+    rows.push(profileImages.slice(i, i + 4));
+  }
+
   return (
-    <div className="flex">
-      {profileImages.slice(0, 4).map((imageUrl, index) => (
-        <div key={index} className={`relative ${index !== 0 ? "-ml-3" : ""}`}>
-          <Avatar key={index} size={"sm"} imageUrl={imageUrl} />
+    <div className="group relative cursor-default">
+      <div className="flex transition-transform duration-200 ease-out hover:scale-105">
+        {profileImages.slice(0, 4).map((imageUrl, index) => (
+          <div key={index} className={`relative ${index !== 0 ? "-ml-3" : ""}`}>
+            <Avatar size="sm" imageUrl={imageUrl} />
+          </div>
+        ))}
+        {count > 4 && (
+          <div className="z-10 -ml-3 flex h-[30px] w-[30px] items-center justify-center rounded-full bg-gray-100 text-sm font-semibold">
+            {`+${count - 4}`}
+          </div>
+        )}
+      </div>
+      <div className="pointer-events-none absolute left-1/2 z-50 mt-1 -translate-x-1/2 transform rounded-md border border-gray-100 bg-white/80 p-2 opacity-0 shadow-sm backdrop-blur-md transition-opacity duration-200 group-hover:opacity-100">
+        <div className="flex flex-col gap-2">
+          {rows.map((row, rowIndex) => (
+            <div
+              key={rowIndex}
+              className="flex translate-y-4 justify-start gap-2 opacity-0 transition-all duration-500 group-hover:translate-y-0 group-hover:opacity-100"
+              style={{ transitionDelay: `${rowIndex * 200}ms` }}
+            >
+              {row.map((url, colIndex) => (
+                <Avatar key={colIndex} size="sm" imageUrl={url} />
+              ))}
+            </div>
+          ))}
         </div>
-      ))}
-      {count > 4 ? (
-        <div className="z-50 -ml-3 flex h-[30px] w-[30px] items-center justify-center rounded-full bg-gray-100 text-sm font-semibold">
-          {`+${count - 4}`}
-        </div>
-      ) : null}
+      </div>
     </div>
   );
 }

--- a/src/app/(common)/gathering/_components/GatheredProfiles.tsx
+++ b/src/app/(common)/gathering/_components/GatheredProfiles.tsx
@@ -13,7 +13,7 @@ export default function GatheredProfiles({ profileImages }: GatheredProfilesProp
   }
 
   return (
-    <div className="group relative cursor-default">
+    <div className="group relative cursor-default" aria-label="모암 참여자 프로필 이미지 목록">
       <div className="flex transition-transform duration-200 ease-out hover:scale-105">
         {profileImages.slice(0, 4).map((imageUrl, index) => (
           <div key={index} className={`relative ${index !== 0 ? "-ml-3" : ""}`}>
@@ -26,7 +26,11 @@ export default function GatheredProfiles({ profileImages }: GatheredProfilesProp
           </div>
         )}
       </div>
-      <div className="pointer-events-none absolute left-1/2 z-50 mt-1 -translate-x-1/2 transform rounded-md border border-gray-100 bg-white/80 p-2 opacity-0 shadow-sm backdrop-blur-md transition-opacity duration-200 group-hover:opacity-100">
+      <div
+        className="pointer-events-none absolute left-1/2 z-50 mt-1 -translate-x-1/2 transform rounded-md border border-gray-100 bg-white/80 p-2 opacity-0 shadow-sm backdrop-blur-md transition-opacity duration-200 group-hover:opacity-100"
+        role="tooltip"
+        aria-hidden={true}
+      >
         <div className="flex flex-col gap-2">
           {rows.map((row, rowIndex) => (
             <div


### PR DESCRIPTION
## Description

상세페이지 프로필 그룹 hover시 숨겨진 프로필 사진을 확인 할 수 있도록 애니메이션 구현했습니다

## Changes Made


- [x] 기능 추가: ✅
- hover animation 추가

## Screenshots (선택)

![화면 기록 2025-03-06 오후 3 06 18](https://github.com/user-attachments/assets/4f6e41b0-39ca-4883-8b36-0d1e8d252f75)

## IssueNumber
#207 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 프로필 이미지가 4개씩 그룹화되어 깔끔하게 표시되고, 추가 이미지가 있을 경우 배지로 안내됩니다.
  - 호버 시 이미지 컨테이너가 확대되며, 툴팁 형태로 추가 이미지가 부드러운 전환과 함께 표시되어 사용자 인터페이스가 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->