### PR TITLE
마이페이지 - 프리 페칭 수정

### DIFF
--- a/src/app/(common)/mypage/_components/MyGatherings.tsx
+++ b/src/app/(common)/mypage/_components/MyGatherings.tsx
@@ -44,7 +44,7 @@ export default function MyGatherings() {
   return (
     <>
       <MypageList
-        queryOption={{ queryFn: () => fetchMyGatherings(), queryKey: ["user", "gatherings"] }}
+        queryOption={{ queryFn: () => fetchMyGatherings(), queryKey: ["user", "gatherings", "joined"] }}
         emptyMessage={"신청한 모임이 아직 없어요"}
         render={(gathering) => (
           <div className="relative py-6" key={gathering.id}>

--- a/src/app/(common)/mypage/_components/MyReviews.tsx
+++ b/src/app/(common)/mypage/_components/MyReviews.tsx
@@ -25,7 +25,7 @@ export default function MyReviews() {
         }}
         emptyMessage={"아직 작성 가능한 리뷰가 없어요"}
         render={(review) => (
-          <Link href={`/gathering/${review.Gathering.id}`}>
+          <Link href={`/gathering/${review.Gathering.id}`} key={review.id}>
             <ListItem
               CardImage={
                 <Image
@@ -36,7 +36,6 @@ export default function MyReviews() {
                   className="h-[156px] w-full rounded-3xl md:max-w-[280px]"
                 />
               }
-              key={review.id}
               className="w-full justify-between"
             >
               <div className="flex h-full w-full flex-col gap-2 border-b-2 border-dashed pb-6">

--- a/src/app/(common)/mypage/_components/MypageContent.tsx
+++ b/src/app/(common)/mypage/_components/MypageContent.tsx
@@ -5,10 +5,15 @@ import MyGatherings from "@/app/(common)/mypage/_components/MyGatherings";
 import MyReviews from "@/app/(common)/mypage/_components/MyReviews";
 import ReviewableGatherings from "@/app/(common)/mypage/_components/ReviewableGatherings";
 import useMypageTab from "@/app/(common)/mypage/_hooks/useMypageTab";
+import { MyGathering } from "@/app/(common)/mypage/types";
 import CategoryButton from "@/components/CategoryButton";
 import ErrorBoundary from "@/components/ErrorBoundary";
 import Spinner from "@/components/Spinner";
 import Tab from "@/components/Tab";
+import axiosInstance from "@/lib/axiosInstance";
+import { UserType, ReviewsResponse, GatheringType } from "@/types";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import dayjs from "dayjs";
 import { Suspense } from "react";
 
 const TAB_ITEMS = ["나의 모임", "나의 리뷰", "내가 만든 모임"];
@@ -20,7 +25,52 @@ const CATEGORIES = ["작성 가능한 리뷰", "작성한 리뷰"];
 // 내가 만든 모임 -> 모임 목록 조회 (모임 생성자(id) 로 필터링)
 
 export default function MypageContent() {
+  const queryClient = useQueryClient();
   const { selectedTab, setSelectedTab, selectedCategory, setSelectedCategory } = useMypageTab();
+  useQuery({
+    queryKey: ["user", "reviews", "reviewable"],
+    queryFn: async () => {
+      const response = await axiosInstance.get<MyGathering[]>("gatherings/joined", {
+        params: {
+          limit: 100,
+          completed: true,
+          reviewed: false,
+        },
+      });
+      const data = response.data.filter((gathering) => !gathering.canceledAt);
+      return data.sort((a, b) => dayjs(b.dateTime).valueOf() - dayjs(a.dateTime).valueOf());
+    },
+  });
+  useQuery({
+    queryKey: ["user", "reviews", "written"],
+    queryFn: async () => {
+      const user = queryClient.getQueryData<UserType>(["user"]);
+      const response = await axiosInstance.get<ReviewsResponse>("reviews", {
+        params: {
+          limit: 100,
+          userId: user?.id,
+        },
+      });
+
+      return response.data.data.sort((a, b) => dayjs(b.createdAt).valueOf() - dayjs(a.createdAt).valueOf());
+    },
+  });
+  useQuery({
+    queryKey: ["user", "gatherings", "created"],
+    queryFn: async () => {
+      const user = queryClient.getQueryData<UserType>(["user"]);
+      const response = await axiosInstance.get<GatheringType[]>(`gatherings`, {
+        params: {
+          limit: 100,
+          sortBy: "dateTime",
+          sortOrder: "desc",
+          createdBy: user?.id,
+        },
+      });
+
+      return response.data;
+    },
+  });
   return (
     <div className="flex flex-1 flex-col gap-6 border-t-2 border-gray-900 bg-white p-6">
       <Tab

--- a/src/app/(common)/mypage/page.tsx
+++ b/src/app/(common)/mypage/page.tsx
@@ -22,7 +22,7 @@ export default async function Page() {
     },
   });
   await queryClient.prefetchQuery({
-    queryKey: ["user", "gatherings"],
+    queryKey: ["user", "gatherings", "joined"],
     queryFn: async () => {
       const response = await axiosInstance.get<MyGathering[]>("gatherings/joined", {
         params: {

--- a/src/app/(common)/mypage/page.tsx
+++ b/src/app/(common)/mypage/page.tsx
@@ -35,12 +35,12 @@ export default async function Page() {
 
   return (
     <div className="flex flex-1 flex-col gap-[30px] pt-8">
+      <div className="flex flex-col gap-6">
+        <h2 className="text-2xl font-semibold">마이 페이지</h2>
+        <ProfileSection />
+      </div>
+      {/* 마이페이지의 콘텐츠 */}
       <HydrationBoundary state={dehydrate(queryClient)}>
-        <div className="flex flex-col gap-6">
-          <h2 className="text-2xl font-semibold">마이 페이지</h2>
-          <ProfileSection />
-        </div>
-        {/* 마이페이지의 콘텐츠 */}
         <MypageContent />
       </HydrationBoundary>
     </div>

--- a/src/app/(common)/mypage/page.tsx
+++ b/src/app/(common)/mypage/page.tsx
@@ -3,7 +3,7 @@ import { ProfileSection } from "@/app/(common)/mypage/_components/ProfileSection
 import { MyGathering } from "@/app/(common)/mypage/types";
 import axiosInstance from "@/lib/axiosInstance";
 import getQueryClient from "@/lib/getQueryClient";
-import { GatheringType, ReviewsResponse, UserType } from "@/types";
+import { UserType } from "@/types";
 import { HydrationBoundary, dehydrate } from "@tanstack/react-query";
 
 import dayjs from "dayjs";
@@ -17,68 +17,21 @@ export default async function Page() {
   await queryClient.prefetchQuery({
     queryKey: ["user"],
     queryFn: async () => {
-      const response = await axiosInstance.get<UserType>("auths/user", {});
+      const response = await axiosInstance.get<UserType>("auths/user");
       return response.data;
     },
   });
-  await Promise.all([
-    queryClient.prefetchQuery({
-      queryKey: ["user", "gatherings"],
-      queryFn: async () => {
-        const response = await axiosInstance.get<MyGathering[]>("gatherings/joined", {
-          params: {
-            limit: 100,
-          },
-        });
-        return response.data.sort((a, b) => dayjs(b.dateTime).valueOf() - dayjs(a.dateTime).valueOf());
-      },
-    }),
-
-    queryClient.prefetchQuery({
-      queryKey: ["user", "reviews", "reviewable"],
-      queryFn: async () => {
-        const response = await axiosInstance.get<MyGathering[]>("gatherings/joined", {
-          params: {
-            limit: 100,
-            completed: true,
-            reviewed: false,
-          },
-        });
-        const data = response.data.filter((gathering) => !gathering.canceledAt);
-        return data.sort((a, b) => dayjs(b.dateTime).valueOf() - dayjs(a.dateTime).valueOf());
-      },
-    }),
-    queryClient.prefetchQuery({
-      queryKey: ["user", "reviews", "written"],
-      queryFn: async () => {
-        const user = queryClient.getQueryData<UserType>(["user"]);
-        const response = await axiosInstance.get<ReviewsResponse>("reviews", {
-          params: {
-            limit: 100,
-            userId: user?.id,
-          },
-        });
-
-        return response.data.data.sort((a, b) => dayjs(b.createdAt).valueOf() - dayjs(a.createdAt).valueOf());
-      },
-    }),
-    queryClient.prefetchQuery({
-      queryKey: ["user", "gatherings", "created"],
-      queryFn: async () => {
-        const user = queryClient.getQueryData<UserType>(["user"]);
-        const response = await axiosInstance.get<GatheringType[]>(`gatherings`, {
-          params: {
-            limit: 100,
-            sortBy: "dateTime",
-            sortOrder: "desc",
-            createdBy: user?.id,
-          },
-        });
-
-        return response.data;
-      },
-    }),
-  ]);
+  await queryClient.prefetchQuery({
+    queryKey: ["user", "gatherings"],
+    queryFn: async () => {
+      const response = await axiosInstance.get<MyGathering[]>("gatherings/joined", {
+        params: {
+          limit: 100,
+        },
+      });
+      return response.data.sort((a, b) => dayjs(b.dateTime).valueOf() - dayjs(a.dateTime).valueOf());
+    },
+  });
 
   return (
     <div className="flex flex-1 flex-col gap-[30px] pt-8">


### PR DESCRIPTION
## Description

마이페이지에서 프리 페칭을 수정했습니다.

## Changes Made

- [x] 기능 추가: ✅
- [x] 코드 리팩토링: 🔧

- 기존에 마이페이지에서 모든 데이터를 서버에서 prefetch 시키던 걸 나의 모임 데이터만 서버 prefetch로 바꿨습니다.
- 내가 작성한 리뷰에 key prop 줬습니다.
- 수화가 계속 실패하는 이유가 userInfo때문인거 같아서요... 일단 HydrationBoundary 위치를 옮겼습니다.  
## Screenshots

## IssueNumber

#202


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - 사용자 마이페이지에서 리뷰 및 모임 데이터를 보다 효과적으로 불러와, 최신 정보와 정렬된 결과를 제공합니다.
  - 개선된 페이지 레이아웃을 통해 프로필 섹션과 헤더가 명확하게 표시되어 사용자 경험이 향상되었습니다.

- **Refactor**
  - 리뷰 리스트 렌더링 방식을 최적화하여 컴포넌트 업데이트의 효율성과 안정성을 개선하였습니다.
  - 데이터 가져오기 로직을 간소화하여 사용자 관련 정보를 보다 효율적으로 처리합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->