### PR TITLE
마이 페이지 - 시간 utc설정 및 프리페칭 로직 수정

### DIFF
--- a/src/app/(common)/mypage/_components/MypageContent.tsx
+++ b/src/app/(common)/mypage/_components/MypageContent.tsx
@@ -4,6 +4,7 @@ import MyCreatedGatherings from "@/app/(common)/mypage/_components/MyCreatedGath
 import MyGatherings from "@/app/(common)/mypage/_components/MyGatherings";
 import MyReviews from "@/app/(common)/mypage/_components/MyReviews";
 import ReviewableGatherings from "@/app/(common)/mypage/_components/ReviewableGatherings";
+import { useGetUserInfo } from "@/app/(common)/mypage/_hooks/useGetUserInfo";
 import useMypageTab from "@/app/(common)/mypage/_hooks/useMypageTab";
 import { MyGathering } from "@/app/(common)/mypage/types";
 import CategoryButton from "@/components/CategoryButton";
@@ -27,6 +28,8 @@ const CATEGORIES = ["작성 가능한 리뷰", "작성한 리뷰"];
 export default function MypageContent() {
   const queryClient = useQueryClient();
   const { selectedTab, setSelectedTab, selectedCategory, setSelectedCategory } = useMypageTab();
+  const { data } = useGetUserInfo("");
+  const id = data?.id;
   useQuery({
     queryKey: ["user", "reviews", "reviewable"],
     queryFn: async () => {
@@ -54,6 +57,7 @@ export default function MypageContent() {
 
       return response.data.data.sort((a, b) => dayjs(b.createdAt).valueOf() - dayjs(a.createdAt).valueOf());
     },
+    enabled: Boolean(id),
   });
   useQuery({
     queryKey: ["user", "gatherings", "created"],
@@ -70,6 +74,7 @@ export default function MypageContent() {
 
       return response.data;
     },
+    enabled: Boolean(id),
   });
   return (
     <div className="flex flex-1 flex-col gap-6 border-t-2 border-gray-900 bg-white p-6">

--- a/src/components/ListItem.tsx
+++ b/src/components/ListItem.tsx
@@ -146,7 +146,7 @@ ListItem.MetaInfo = ({ imageUrl, primary, secondary }: MetaInfoProps) => {
           <span className="mr-3 text-xs text-gray-700">|</span>
         </div>
       )}
-      <span className="text-xs text-gray-500">{dayjs(secondary).format("YYYY.MM.DD")}</span>
+      <span className="text-xs text-gray-500">{dayjs(secondary).utc().format("YYYY.MM.DD")}</span>
     </div>
   );
 };

--- a/src/components/ListItem.tsx
+++ b/src/components/ListItem.tsx
@@ -6,7 +6,9 @@ import Check from "@/images/check.svg";
 import { PropsWithChildren } from "react";
 import InactiveLayer from "@/components/InactiveLayer";
 import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
 
+dayjs.extend(utc);
 type ListItemProps = {
   CardImage?: React.ReactNode;
   canceledAt?: string | null;
@@ -102,8 +104,8 @@ type SubInfoProps = {
   capacity: number;
 };
 ListItem.SubInfo = ({ date, participantCount, capacity }: SubInfoProps) => {
-  const formatDate = dayjs(date).format("M월 D일");
-  const formatTime = dayjs(date).format("HH:mm");
+  const formatDate = dayjs(date).utc().format("M월 D일");
+  const formatTime = dayjs(date).utc().format("HH:mm");
   return (
     <div className="flex items-center gap-3 text-sm text-gray-700">
       <div>{`${formatDate} · ${formatTime}`}</div>


### PR DESCRIPTION
## Description

LIstItem시간에 utc설정 해줬고, 프리페칭하는 로직 수정해줬습니다.

## Changes Made

[변경사항 리스트를 적습니다.]

- [x] 기능 추가: ✅
- [x] 코드 리팩토링: 🔧

- LIstItem에 utc설정
- MyContent에서 프리페칭시 userId가 없으면 enabled: false 설정

## Screenshots (선택)

## IssueNumber

#202


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 사용자 정보를 기반으로 리뷰 및 모임 관련 데이터를 조건부로 불러오도록 개선하여, 올바른 사용자 정보가 있을 때만 관련 콘텐츠가 표시됩니다.
  
- **스타일**
  - 날짜와 시간 표기를 UTC 기준으로 표준화하여, 일관된 시간 정보 제공으로 사용자 경험이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->