### PR TITLE
마이페이지 - 나의 모임 동작(리뷰, 취소) 의 로딩 및 에러 핸들링

### DIFF
--- a/src/app/(common)/mypage/_components/CancelConfirmModal.tsx
+++ b/src/app/(common)/mypage/_components/CancelConfirmModal.tsx
@@ -4,8 +4,9 @@ type CancelConfirmModalProps = {
   isOpen: boolean;
   onClose: () => void;
   onConfirm: (e: React.MouseEvent<HTMLButtonElement>) => Promise<void>;
+  isPending: boolean;
 };
-export default function CancelConfirmModal({ isOpen, onClose, onConfirm }: CancelConfirmModalProps) {
+export default function CancelConfirmModal({ isOpen, onClose, onConfirm, isPending }: CancelConfirmModalProps) {
   return (
     <Modal isOpen={isOpen} onClose={onClose}>
       <div className="w-full max-w-[340px]">
@@ -16,7 +17,7 @@ export default function CancelConfirmModal({ isOpen, onClose, onConfirm }: Cance
           <Button styleType="outline" onClick={onClose} size="sm" className="w-full">
             닫기
           </Button>
-          <Button onClick={onConfirm} size="sm" className="w-full">
+          <Button disabled={isPending} onClick={onConfirm} size="sm" className="w-full" loading={isPending}>
             확인
           </Button>
         </div>

--- a/src/app/(common)/mypage/_components/CancelConfirmModal.tsx
+++ b/src/app/(common)/mypage/_components/CancelConfirmModal.tsx
@@ -1,0 +1,26 @@
+import Button from "@/components/Button";
+import Modal from "@/components/Modal";
+type CancelConfirmModalProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: (e: React.MouseEvent<HTMLButtonElement>) => Promise<void>;
+};
+export default function CancelConfirmModal({ isOpen, onClose, onConfirm }: CancelConfirmModalProps) {
+  return (
+    <Modal isOpen={isOpen} onClose={onClose}>
+      <div className="w-full max-w-[340px]">
+        <p className="m-12 break-keep text-center text-sm font-medium text-gray-900 md:text-base">
+          예약을 취소하시겠어요?
+        </p>
+        <div className="m-auto flex w-full gap-2">
+          <Button styleType="outline" onClick={onClose} size="sm" className="w-full">
+            닫기
+          </Button>
+          <Button onClick={onConfirm} size="sm" className="w-full">
+            확인
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/src/app/(common)/mypage/_components/CancelConfirmModal.tsx
+++ b/src/app/(common)/mypage/_components/CancelConfirmModal.tsx
@@ -1,7 +1,7 @@
-import Button from "@/components/Button";
-import Modal from "@/components/Modal";
+import { Popup } from "@/components/Popup";
 import { useLeaveGathering } from "@/hooks/useLeaveGathering";
-import { MouseEvent, useState } from "react";
+import { useState } from "react";
+
 type CancelConfirmModalProps = {
   isOpen: boolean;
   onClose: () => void;
@@ -19,8 +19,7 @@ export default function CancelConfirmModal({
   const handleErrorModalClose = () => {
     setIsModalOpen(false);
   };
-  const handleCancelGathering = async (e: MouseEvent<HTMLButtonElement>) => {
-    e.preventDefault();
+  const handleCancelGathering = () => {
     mutation.mutate(gatheringId as number, {
       onSuccess: () => {
         handleModalClose();
@@ -33,37 +32,12 @@ export default function CancelConfirmModal({
 
   return (
     <>
-      <Modal isOpen={isOpen} onClose={onClose}>
-        <div className="w-full max-w-[340px]">
-          <p className="m-12 break-keep text-center text-sm font-medium text-gray-900 md:text-base">
-            예약을 취소하시겠어요?
-          </p>
-          <div className="m-auto flex w-full gap-2">
-            <Button styleType="outline" onClick={onClose} size="sm" className="w-full">
-              닫기
-            </Button>
-            <Button
-              disabled={mutation.isPending}
-              onClick={handleCancelGathering}
-              size="sm"
-              className="w-full"
-              loading={mutation.isPending}
-            >
-              확인
-            </Button>
-          </div>
-        </div>
-      </Modal>
-      <Modal isOpen={isModalOpen} onClose={handleErrorModalClose}>
-        <div className="w-full min-w-[252px]">
-          <p className="py-12 text-center text-base font-medium text-gray-900">에러: {mutation.error?.message}</p>
-          <div className="m-auto flex w-[120px]">
-            <Button onClick={handleErrorModalClose} size="sm" className="w-full">
-              확인
-            </Button>
-          </div>
-        </div>
-      </Modal>
+      <Popup isOpen={isOpen} onClose={onClose} type="confirm" onClick={handleCancelGathering}>
+        예약을 취소하시겠어요?
+      </Popup>
+      <Popup isOpen={isModalOpen} onClose={handleErrorModalClose} onClick={handleErrorModalClose} type="alert">
+        에러: {mutation.error?.message}
+      </Popup>
     </>
   );
 }

--- a/src/app/(common)/mypage/_components/CancelConfirmModal.tsx
+++ b/src/app/(common)/mypage/_components/CancelConfirmModal.tsx
@@ -1,27 +1,69 @@
 import Button from "@/components/Button";
 import Modal from "@/components/Modal";
+import { useLeaveGathering } from "@/hooks/useLeaveGathering";
+import { MouseEvent, useState } from "react";
 type CancelConfirmModalProps = {
   isOpen: boolean;
   onClose: () => void;
-  onConfirm: (e: React.MouseEvent<HTMLButtonElement>) => Promise<void>;
-  isPending: boolean;
+  gatheringId: number;
+  handleModalClose: () => void;
 };
-export default function CancelConfirmModal({ isOpen, onClose, onConfirm, isPending }: CancelConfirmModalProps) {
+export default function CancelConfirmModal({
+  isOpen,
+  onClose,
+  gatheringId,
+  handleModalClose,
+}: CancelConfirmModalProps) {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const mutation = useLeaveGathering(["user", "gatherings"]);
+  const handleErrorModalClose = () => {
+    setIsModalOpen(false);
+  };
+  const handleCancelGathering = async (e: MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    mutation.mutate(gatheringId as number, {
+      onSuccess: () => {
+        handleModalClose();
+      },
+      onError: () => {
+        setIsModalOpen(true);
+      },
+    });
+  };
+
   return (
-    <Modal isOpen={isOpen} onClose={onClose}>
-      <div className="w-full max-w-[340px]">
-        <p className="m-12 break-keep text-center text-sm font-medium text-gray-900 md:text-base">
-          예약을 취소하시겠어요?
-        </p>
-        <div className="m-auto flex w-full gap-2">
-          <Button styleType="outline" onClick={onClose} size="sm" className="w-full">
-            닫기
-          </Button>
-          <Button disabled={isPending} onClick={onConfirm} size="sm" className="w-full" loading={isPending}>
-            확인
-          </Button>
+    <>
+      <Modal isOpen={isOpen} onClose={onClose}>
+        <div className="w-full max-w-[340px]">
+          <p className="m-12 break-keep text-center text-sm font-medium text-gray-900 md:text-base">
+            예약을 취소하시겠어요?
+          </p>
+          <div className="m-auto flex w-full gap-2">
+            <Button styleType="outline" onClick={onClose} size="sm" className="w-full">
+              닫기
+            </Button>
+            <Button
+              disabled={mutation.isPending}
+              onClick={handleCancelGathering}
+              size="sm"
+              className="w-full"
+              loading={mutation.isPending}
+            >
+              확인
+            </Button>
+          </div>
         </div>
-      </div>
-    </Modal>
+      </Modal>
+      <Modal isOpen={isModalOpen} onClose={handleErrorModalClose}>
+        <div className="w-full min-w-[252px]">
+          <p className="py-12 text-center text-base font-medium text-gray-900">에러: {mutation.error?.message}</p>
+          <div className="m-auto flex w-[120px]">
+            <Button onClick={handleErrorModalClose} size="sm" className="w-full">
+              확인
+            </Button>
+          </div>
+        </div>
+      </Modal>
+    </>
   );
 }

--- a/src/app/(common)/mypage/_components/MyGatherings.tsx
+++ b/src/app/(common)/mypage/_components/MyGatherings.tsx
@@ -57,8 +57,11 @@ export default function MyGatherings() {
 
   const handleCancelGathering = async (e: MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
-    mutation.mutate(selectedCancelGathering as number);
-    handleCancelModalClose();
+    mutation.mutate(selectedCancelGathering as number, {
+      onSuccess: () => {
+        handleCancelModalClose();
+      },
+    });
   };
   return (
     <>
@@ -132,6 +135,7 @@ export default function MyGatherings() {
           isOpen={isCancelModalOpen}
           onClose={handleCancelModalClose}
           onConfirm={handleCancelGathering}
+          isPending={mutation.isPending}
         />
       )}
     </>

--- a/src/app/(common)/mypage/_components/MyGatherings.tsx
+++ b/src/app/(common)/mypage/_components/MyGatherings.tsx
@@ -1,7 +1,7 @@
 import ListItem from "@/components/ListItem";
 import Image from "next/image";
 import Button from "@/components/Button";
-import { MouseEvent, useState } from "react";
+import { useState } from "react";
 import { useLeaveGathering } from "@/hooks/useLeaveGathering";
 import MypageList from "@/app/(common)/mypage/_components/MypageList";
 import { fetchMyGatherings } from "@/app/(common)/mypage/utils/apis";
@@ -9,6 +9,7 @@ import DEFAULT_IMAGE from "@/images/default_image.png";
 import { ReviewModal } from "@/app/(common)/mypage/_components/ReviewModal";
 import Link from "next/link";
 import CancelConfirmModal from "@/app/(common)/mypage/_components/CancelConfirmModal";
+import useMypageModal from "@/app/(common)/mypage/_hooks/useMypageModal";
 
 // 이용 예정 => 모임 참여 신청했고 isCompleted가 false인 경우
 // 이용 완료 => 모임 참여 신청했고 isCompleted가 true인 경우
@@ -29,20 +30,12 @@ import CancelConfirmModal from "@/app/(common)/mypage/_components/CancelConfirmM
 // isCompleted가 true, isReviewed가 true => 리뷰 작성 x
 
 export default function MyGatherings() {
-  const [isModalOpen, setModalOpen] = useState(false);
-  const [selectedGathering, setSelectedGathering] = useState<number>();
+  // 리뷰 모달
+  const { isModalOpen, selectedGathering, handleOpen, handleClose } = useMypageModal();
 
   // 취소 확인 모달
   const [isCancelModalOpen, setCancelModalOpen] = useState(false);
   const [selectedCancelGathering, setSelectedCancelGathering] = useState<number>();
-  const handleOpen = (gatheringId: number) => {
-    setSelectedGathering(gatheringId);
-    setModalOpen(true);
-  };
-
-  const handleClose = () => {
-    setModalOpen(false);
-  };
 
   const handleCancelModalOpen = (gatheringId: number) => {
     setSelectedCancelGathering(gatheringId);
@@ -55,14 +48,6 @@ export default function MyGatherings() {
 
   const mutation = useLeaveGathering(["user", "gatherings"]);
 
-  const handleCancelGathering = async (e: MouseEvent<HTMLButtonElement>) => {
-    e.preventDefault();
-    mutation.mutate(selectedCancelGathering as number, {
-      onSuccess: () => {
-        handleCancelModalClose();
-      },
-    });
-  };
   return (
     <>
       <MypageList
@@ -133,8 +118,8 @@ export default function MyGatherings() {
       <CancelConfirmModal
         isOpen={isCancelModalOpen}
         onClose={handleCancelModalClose}
-        onConfirm={handleCancelGathering}
-        isPending={mutation.isPending}
+        gatheringId={selectedCancelGathering as number}
+        handleModalClose={handleCancelModalClose}
       />
     </>
   );

--- a/src/app/(common)/mypage/_components/MyGatherings.tsx
+++ b/src/app/(common)/mypage/_components/MyGatherings.tsx
@@ -1,13 +1,14 @@
 import ListItem from "@/components/ListItem";
 import Image from "next/image";
 import Button from "@/components/Button";
-import { useState } from "react";
+import { MouseEvent, useState } from "react";
 import { useLeaveGathering } from "@/hooks/useLeaveGathering";
 import MypageList from "@/app/(common)/mypage/_components/MypageList";
 import { fetchMyGatherings } from "@/app/(common)/mypage/utils/apis";
 import DEFAULT_IMAGE from "@/images/default_image.png";
 import { ReviewModal } from "@/app/(common)/mypage/_components/ReviewModal";
 import Link from "next/link";
+import CancelConfirmModal from "@/app/(common)/mypage/_components/CancelConfirmModal";
 
 // 이용 예정 => 모임 참여 신청했고 isCompleted가 false인 경우
 // 이용 완료 => 모임 참여 신청했고 isCompleted가 true인 경우
@@ -30,6 +31,10 @@ import Link from "next/link";
 export default function MyGatherings() {
   const [isModalOpen, setModalOpen] = useState(false);
   const [selectedGathering, setSelectedGathering] = useState<number | null>(null);
+
+  // 취소 확인 모달
+  const [isCancelModalOpen, setCancelModalOpen] = useState(false);
+  const [selectedCancelGathering, setSelectedCancelGathering] = useState<number | null>(null);
   const handleOpen = (gatheringId: number) => {
     setSelectedGathering(gatheringId);
     setModalOpen(true);
@@ -39,8 +44,22 @@ export default function MyGatherings() {
     setModalOpen(false);
   };
 
+  const handleCancelModalOpen = (gatheringId: number) => {
+    setSelectedCancelGathering(gatheringId);
+    setCancelModalOpen(true);
+  };
+
+  const handleCancelModalClose = () => {
+    setCancelModalOpen(false);
+  };
+
   const mutation = useLeaveGathering(["user", "gatherings"]);
 
+  const handleCancelGathering = async (e: MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    mutation.mutate(selectedCancelGathering as number);
+    handleCancelModalClose();
+  };
   return (
     <>
       <MypageList
@@ -89,7 +108,8 @@ export default function MyGatherings() {
                           }
                         : (e) => {
                             e.preventDefault();
-                            mutation.mutate(gathering.id);
+                            handleCancelModalOpen(gathering.id);
+                            // mutation.mutate(gathering.id);
                           }
                     }
                     className={"mt-[18px] w-full max-w-[120px]"}
@@ -107,6 +127,13 @@ export default function MyGatherings() {
         )}
       />
       {selectedGathering && <ReviewModal isOpen={isModalOpen} onClose={handleClose} gatheringId={selectedGathering} />}
+      {selectedCancelGathering && (
+        <CancelConfirmModal
+          isOpen={isCancelModalOpen}
+          onClose={handleCancelModalClose}
+          onConfirm={handleCancelGathering}
+        />
+      )}
     </>
   );
 }

--- a/src/app/(common)/mypage/_components/MyGatherings.tsx
+++ b/src/app/(common)/mypage/_components/MyGatherings.tsx
@@ -30,11 +30,11 @@ import CancelConfirmModal from "@/app/(common)/mypage/_components/CancelConfirmM
 
 export default function MyGatherings() {
   const [isModalOpen, setModalOpen] = useState(false);
-  const [selectedGathering, setSelectedGathering] = useState<number | null>(null);
+  const [selectedGathering, setSelectedGathering] = useState<number>();
 
   // 취소 확인 모달
   const [isCancelModalOpen, setCancelModalOpen] = useState(false);
-  const [selectedCancelGathering, setSelectedCancelGathering] = useState<number | null>(null);
+  const [selectedCancelGathering, setSelectedCancelGathering] = useState<number>();
   const handleOpen = (gatheringId: number) => {
     setSelectedGathering(gatheringId);
     setModalOpen(true);
@@ -129,15 +129,13 @@ export default function MyGatherings() {
           </div>
         )}
       />
-      {selectedGathering && <ReviewModal isOpen={isModalOpen} onClose={handleClose} gatheringId={selectedGathering} />}
-      {selectedCancelGathering && (
-        <CancelConfirmModal
-          isOpen={isCancelModalOpen}
-          onClose={handleCancelModalClose}
-          onConfirm={handleCancelGathering}
-          isPending={mutation.isPending}
-        />
-      )}
+      <ReviewModal isOpen={isModalOpen} onClose={handleClose} gatheringId={selectedGathering as number} />
+      <CancelConfirmModal
+        isOpen={isCancelModalOpen}
+        onClose={handleCancelModalClose}
+        onConfirm={handleCancelGathering}
+        isPending={mutation.isPending}
+      />
     </>
   );
 }

--- a/src/app/(common)/mypage/_components/MyGatherings.tsx
+++ b/src/app/(common)/mypage/_components/MyGatherings.tsx
@@ -1,7 +1,6 @@
 import ListItem from "@/components/ListItem";
 import Image from "next/image";
 import Button from "@/components/Button";
-import { useState } from "react";
 import { useLeaveGathering } from "@/hooks/useLeaveGathering";
 import MypageList from "@/app/(common)/mypage/_components/MypageList";
 import { fetchMyGatherings } from "@/app/(common)/mypage/utils/apis";
@@ -34,20 +33,14 @@ export default function MyGatherings() {
   const { isModalOpen, selectedGathering, handleOpen, handleClose } = useMypageModal();
 
   // 취소 확인 모달
-  const [isCancelModalOpen, setCancelModalOpen] = useState(false);
-  const [selectedCancelGathering, setSelectedCancelGathering] = useState<number>();
-
-  const handleCancelModalOpen = (gatheringId: number) => {
-    setSelectedCancelGathering(gatheringId);
-    setCancelModalOpen(true);
-  };
-
-  const handleCancelModalClose = () => {
-    setCancelModalOpen(false);
-  };
+  const {
+    isModalOpen: isCancelModalOpen,
+    selectedGathering: cancelGathering,
+    handleOpen: handleCancelGathering,
+    handleClose: handleCancelGatheringClose,
+  } = useMypageModal();
 
   const mutation = useLeaveGathering(["user", "gatherings"]);
-
   return (
     <>
       <MypageList
@@ -96,8 +89,7 @@ export default function MyGatherings() {
                           }
                         : (e) => {
                             e.preventDefault();
-                            handleCancelModalOpen(gathering.id);
-                            // mutation.mutate(gathering.id);
+                            handleCancelGathering(gathering.id);
                           }
                     }
                     className={"mt-[18px] w-full max-w-[120px]"}
@@ -117,9 +109,9 @@ export default function MyGatherings() {
       <ReviewModal isOpen={isModalOpen} onClose={handleClose} gatheringId={selectedGathering as number} />
       <CancelConfirmModal
         isOpen={isCancelModalOpen}
-        onClose={handleCancelModalClose}
-        gatheringId={selectedCancelGathering as number}
-        handleModalClose={handleCancelModalClose}
+        onClose={handleCancelGatheringClose}
+        gatheringId={cancelGathering as number}
+        handleModalClose={handleCancelGatheringClose}
       />
     </>
   );

--- a/src/app/(common)/mypage/_components/ProfileSection/ProfileEditModal.tsx
+++ b/src/app/(common)/mypage/_components/ProfileSection/ProfileEditModal.tsx
@@ -6,6 +6,7 @@ import Input from "@/components/Input";
 import Edit from "@/images/edit.svg";
 import Avatar from "@/components/Avatar";
 import { useProfileEditForm } from "@/app/(common)/mypage/_hooks/useProfileEditForm";
+import { Popup } from "@/components/Popup";
 
 type ProfileEditModalProps = {
   isOpen: boolean;
@@ -61,16 +62,9 @@ export default function ProfileEditModal({ isOpen, onClose }: ProfileEditModalPr
           </div>
         </form>
       </Modal>
-      <Modal isOpen={isModalOpen} onClose={handleModalClose}>
-        <div className="w-full min-w-[252px]">
-          <p className="py-12 text-center text-base font-medium text-gray-900">에러: {mutation.error?.message}</p>
-          <div className="m-auto flex w-[120px]">
-            <Button onClick={handleModalClose} size="sm" className="w-full">
-              확인
-            </Button>
-          </div>
-        </div>
-      </Modal>
+      <Popup isOpen={isModalOpen} onClose={handleModalClose} onClick={handleModalClose} type="alert">
+        에러: {mutation.error?.message}
+      </Popup>
     </>
   );
 }

--- a/src/app/(common)/mypage/_components/ReviewModal/FormActions.tsx
+++ b/src/app/(common)/mypage/_components/ReviewModal/FormActions.tsx
@@ -12,7 +12,7 @@ export const FormActions: React.FC<FormActionsProps> = ({ onCancel, isSubmitDisa
       <Button className="w-full" styleType={"outline"} onClick={onCancel}>
         취소
       </Button>
-      <Button className="w-full" type="submit" disabled={isSubmitDisabled} loading={isPending}>
+      <Button className="w-full" type="submit" disabled={isSubmitDisabled || isPending} loading={isPending}>
         리뷰 등록
       </Button>
     </div>

--- a/src/app/(common)/mypage/_components/ReviewModal/FormActions.tsx
+++ b/src/app/(common)/mypage/_components/ReviewModal/FormActions.tsx
@@ -3,15 +3,16 @@ import Button from "@/components/Button";
 type FormActionsProps = {
   onCancel: () => void;
   isSubmitDisabled: boolean;
+  isPending: boolean;
 };
 
-export const FormActions: React.FC<FormActionsProps> = ({ onCancel, isSubmitDisabled }) => {
+export const FormActions: React.FC<FormActionsProps> = ({ onCancel, isSubmitDisabled, isPending }) => {
   return (
     <div className="flex gap-4">
       <Button className="w-full" styleType={"outline"} onClick={onCancel}>
         취소
       </Button>
-      <Button className="w-full" type="submit" disabled={isSubmitDisabled}>
+      <Button className="w-full" type="submit" disabled={isSubmitDisabled} loading={isPending}>
         리뷰 등록
       </Button>
     </div>

--- a/src/app/(common)/mypage/_components/ReviewModal/ReviewModal.tsx
+++ b/src/app/(common)/mypage/_components/ReviewModal/ReviewModal.tsx
@@ -5,7 +5,7 @@ import CommentInput from "@/app/(common)/mypage/_components/ReviewModal/CommentI
 import { FormActions } from "@/app/(common)/mypage/_components/ReviewModal/FormActions";
 import { useReviewForm } from "@/app/(common)/mypage/_hooks/useReviewForm";
 import RatingInput from "@/app/(common)/mypage/_components/ReviewModal/RatingInput";
-import Button from "@/components/Button";
+import { Popup } from "@/components/Popup";
 
 interface ReviewModalProps {
   isOpen: boolean;
@@ -41,16 +41,9 @@ export default function ReviewModal({ isOpen, onClose, gatheringId }: ReviewModa
           <FormActions onCancel={handleClose} isSubmitDisabled={!isValid} isPending={mutation.isPending} />
         </form>
       </Modal>
-      <Modal isOpen={isModalOpen} onClose={handleErrorModalClose}>
-        <div className="w-full min-w-[252px]">
-          <p className="py-12 text-center text-base font-medium text-gray-900">에러: {mutation.error?.message}</p>
-          <div className="m-auto flex w-[120px]">
-            <Button onClick={handleErrorModalClose} size="sm" className="w-full">
-              확인
-            </Button>
-          </div>
-        </div>
-      </Modal>
+      <Popup isOpen={isModalOpen} onClose={handleErrorModalClose} onClick={handleErrorModalClose} type="alert">
+        에러: {mutation.error?.message}
+      </Popup>
     </>
   );
 }

--- a/src/app/(common)/mypage/_components/ReviewModal/ReviewModal.tsx
+++ b/src/app/(common)/mypage/_components/ReviewModal/ReviewModal.tsx
@@ -13,7 +13,17 @@ interface ReviewModalProps {
 }
 
 export default function ReviewModal({ isOpen, onClose, gatheringId }: ReviewModalProps) {
-  const { control, handleSubmit, isValid, errors, comment, onSubmit, handleClose } = useReviewForm({
+  const {
+    reviewForm: {
+      control,
+      handleSubmit,
+      formState: { isValid, errors },
+    },
+    comment,
+    mutation,
+    onSubmit,
+    handleClose,
+  } = useReviewForm({
     gatheringId,
     onClose,
   });
@@ -24,7 +34,7 @@ export default function ReviewModal({ isOpen, onClose, gatheringId }: ReviewModa
       <form className="flex flex-col gap-6" onSubmit={handleSubmit(onSubmit)}>
         <RatingInput control={control} />
         <CommentInput control={control} errors={errors} commentLength={comment.length} />
-        <FormActions onCancel={handleClose} isSubmitDisabled={!isValid} />
+        <FormActions onCancel={handleClose} isSubmitDisabled={!isValid} isPending={mutation.isPending} />
       </form>
     </Modal>
   );

--- a/src/app/(common)/mypage/_components/ReviewModal/ReviewModal.tsx
+++ b/src/app/(common)/mypage/_components/ReviewModal/ReviewModal.tsx
@@ -5,6 +5,7 @@ import CommentInput from "@/app/(common)/mypage/_components/ReviewModal/CommentI
 import { FormActions } from "@/app/(common)/mypage/_components/ReviewModal/FormActions";
 import { useReviewForm } from "@/app/(common)/mypage/_hooks/useReviewForm";
 import RatingInput from "@/app/(common)/mypage/_components/ReviewModal/RatingInput";
+import Button from "@/components/Button";
 
 interface ReviewModalProps {
   isOpen: boolean;
@@ -23,19 +24,33 @@ export default function ReviewModal({ isOpen, onClose, gatheringId }: ReviewModa
     mutation,
     onSubmit,
     handleClose,
+    isModalOpen,
+    handleErrorModalClose,
   } = useReviewForm({
     gatheringId,
     onClose,
   });
 
   return (
-    <Modal isOpen={isOpen} onClose={handleClose} className="mx-4 flex w-full max-w-[520px] flex-col gap-6 md:mx-0">
-      <div className="text-lg font-semibold">리뷰 쓰기</div>
-      <form className="flex flex-col gap-6" onSubmit={handleSubmit(onSubmit)}>
-        <RatingInput control={control} />
-        <CommentInput control={control} errors={errors} commentLength={comment.length} />
-        <FormActions onCancel={handleClose} isSubmitDisabled={!isValid} isPending={mutation.isPending} />
-      </form>
-    </Modal>
+    <>
+      <Modal isOpen={isOpen} onClose={handleClose} className="mx-4 flex w-full max-w-[520px] flex-col gap-6 md:mx-0">
+        <div className="text-lg font-semibold">리뷰 쓰기</div>
+        <form className="flex flex-col gap-6" onSubmit={handleSubmit(onSubmit)}>
+          <RatingInput control={control} />
+          <CommentInput control={control} errors={errors} commentLength={comment.length} />
+          <FormActions onCancel={handleClose} isSubmitDisabled={!isValid} isPending={mutation.isPending} />
+        </form>
+      </Modal>
+      <Modal isOpen={isModalOpen} onClose={handleErrorModalClose}>
+        <div className="w-full min-w-[252px]">
+          <p className="py-12 text-center text-base font-medium text-gray-900">에러: {mutation.error?.message}</p>
+          <div className="m-auto flex w-[120px]">
+            <Button onClick={handleErrorModalClose} size="sm" className="w-full">
+              확인
+            </Button>
+          </div>
+        </div>
+      </Modal>
+    </>
   );
 }

--- a/src/app/(common)/mypage/_hooks/useMypageModal.ts
+++ b/src/app/(common)/mypage/_hooks/useMypageModal.ts
@@ -1,0 +1,21 @@
+import { useState } from "react";
+
+export default function useMypageModal() {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [selectedGathering, setSelectedGathering] = useState<number>();
+
+  const handleOpen = (gatheringId: number) => {
+    setSelectedGathering(gatheringId);
+    setIsModalOpen(true);
+  };
+  const handleClose = () => {
+    setIsModalOpen(false);
+  };
+
+  return {
+    isModalOpen,
+    selectedGathering,
+    handleOpen,
+    handleClose,
+  };
+}

--- a/src/app/(common)/mypage/_hooks/useReviewForm.ts
+++ b/src/app/(common)/mypage/_hooks/useReviewForm.ts
@@ -1,4 +1,5 @@
 import usePostReviews from "@/app/(common)/mypage/_hooks/usePostReviews";
+import { useState } from "react";
 import { useForm } from "react-hook-form";
 
 export type ReviewFormValues = {
@@ -19,7 +20,11 @@ export const useReviewForm = ({ gatheringId, onClose }: UseReviewFormProps) => {
       comment: "",
     },
   });
+  const [isModalOpen, setIsModalOpen] = useState(false);
 
+  const handleErrorModalClose = () => {
+    setIsModalOpen(false);
+  };
   const comment = reviewForm.watch("comment");
   const mutation = usePostReviews();
 
@@ -30,7 +35,9 @@ export const useReviewForm = ({ gatheringId, onClose }: UseReviewFormProps) => {
         onSuccess: () => {
           onClose();
         },
-        onError: () => {},
+        onError: () => {
+          setIsModalOpen(true);
+        },
       },
     );
   };
@@ -46,5 +53,7 @@ export const useReviewForm = ({ gatheringId, onClose }: UseReviewFormProps) => {
     comment,
     onSubmit,
     handleClose,
+    isModalOpen,
+    handleErrorModalClose,
   };
 };

--- a/src/app/(common)/mypage/_hooks/useReviewForm.ts
+++ b/src/app/(common)/mypage/_hooks/useReviewForm.ts
@@ -12,13 +12,7 @@ export type UseReviewFormProps = {
 };
 
 export const useReviewForm = ({ gatheringId, onClose }: UseReviewFormProps) => {
-  const {
-    control,
-    handleSubmit,
-    formState: { isValid, errors },
-    watch,
-    reset,
-  } = useForm<ReviewFormValues>({
+  const reviewForm = useForm<ReviewFormValues>({
     mode: "onBlur",
     defaultValues: {
       score: 0,
@@ -26,24 +20,29 @@ export const useReviewForm = ({ gatheringId, onClose }: UseReviewFormProps) => {
     },
   });
 
-  const comment = watch("comment");
+  const comment = reviewForm.watch("comment");
   const mutation = usePostReviews();
 
   const onSubmit = (data: ReviewFormValues) => {
-    mutation.mutate({ ...data, gatheringId });
-    onClose();
+    mutation.mutate(
+      { ...data, gatheringId },
+      {
+        onSuccess: () => {
+          onClose();
+        },
+        onError: () => {},
+      },
+    );
   };
 
   const handleClose = () => {
-    reset();
+    reviewForm.reset();
     onClose();
   };
 
   return {
-    control,
-    handleSubmit,
-    isValid,
-    errors,
+    reviewForm,
+    mutation,
     comment,
     onSubmit,
     handleClose,

--- a/src/components/Popup/Popup.tsx
+++ b/src/components/Popup/Popup.tsx
@@ -14,13 +14,13 @@ export default function Popup({ isOpen, type = "alert", onClose, onClick, childr
     <Modal isOpen={isOpen} onClose={onClose} className="w-full max-w-[450px]">
       <div className="flex h-[151px] w-full flex-col items-center justify-between text-base font-medium">
         <div className="flex flex-1 flex-col items-center justify-center">{children}</div>
-        <div className="flex gap-2">
+        <div className="flex w-full justify-center gap-2">
           {type === "confirm" && (
-            <Button styleType="outline" onClick={onClose} className="w-[120px]">
+            <Button styleType="outline" onClick={onClose} className="w-full max-w-[120px]">
               취소
             </Button>
           )}
-          <Button onClick={onClick} className="w-[120px]">
+          <Button onClick={onClick} className="w-full max-w-[120px]">
             확인
           </Button>
         </div>

--- a/src/components/ScrollToTop.tsx
+++ b/src/components/ScrollToTop.tsx
@@ -2,9 +2,11 @@
 
 import { useEffect, useState } from "react";
 import ScrollArrow from "@/images/dropdown_down_arrow_white.svg";
+import { usePathname } from "next/navigation";
 
 export default function ScrollToTop() {
   const [isVisible, setIsVisible] = useState(false);
+  const pathname = usePathname();
 
   useEffect(() => {
     const handleScroll = () => {
@@ -14,7 +16,7 @@ export default function ScrollToTop() {
     window.addEventListener("scroll", handleScroll);
     return () => window.removeEventListener("scroll", handleScroll);
   }, []);
-
+  if (pathname.includes("/gathering")) return null;
   const scrollToTop = () => {
     window.scroll({ top: 0, behavior: "smooth" });
   };

--- a/src/components/ScrollToTop.tsx
+++ b/src/components/ScrollToTop.tsx
@@ -21,7 +21,7 @@ export default function ScrollToTop() {
 
   return (
     <button
-      className={`group fixed bottom-3 right-3 flex size-9 transform items-center justify-center rounded-full bg-blue-6 transition-all duration-300 ease-in-out md:size-12 ${
+      className={`group fixed bottom-3 right-3 z-10 flex size-9 transform items-center justify-center rounded-full bg-blue-6 transition-all duration-300 ease-in-out md:size-12 ${
         isVisible ? "scale-100" : "scale-0"
       }`}
       onClick={scrollToTop}


### PR DESCRIPTION
## Description

 나의 모임 동작(리뷰, 취소) 의 로딩 및 에러 핸들링을 했습니다.
모달이 많이 필요해 헤매면서 작성했습니다. 이상한 부분 있으면 말씀해주세요.
리뷰 실패 시 핸들링 로직은 같은 pr에 추가하겠습니다..!

## Changes Made

[변경사항 리스트를 적습니다.]

- [x] 기능 추가: ✅
- [x] 코드 리팩토링: 🔧

- ScrollToTop버튼 상세 페이지에서는 렌더링 시키지 않도록 구현
- 리뷰 제출 시 확인 버튼을 비활성화 시키도록 구현했습니다.
- 예약 취소를 한 번 더 확인하는 모달을 만들었습니다.
- 예약 취소 실패 시 렌더링 될 에러 모달을 만들었습니다.

## Screenshots (선택)

<img width="622" alt="스크린샷 2025-03-10 오후 6 12 50" src="https://github.com/user-attachments/assets/771a43e5-9278-40cc-bf03-eca14f686503" />
<img width="346" alt="스크린샷 2025-03-10 오후 6 13 27" src="https://github.com/user-attachments/assets/f5952c1f-8473-4452-b9e4-ea5fd2e1aa2d" />
<img width="606" alt="스크린샷 2025-03-10 오후 6 14 28" src="https://github.com/user-attachments/assets/047d5a79-d884-40f0-9c8f-959ddce18289" />

## IssueNumber

#202


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - 갱신 취소 전 확인 모달 도입: 모임 취소 시 추가 확인 단계를 통해 실수를 방지합니다.
  - 리뷰 제출 시 로딩 상태 반영: 제출 중 버튼이 비활성화되어 중복 제출을 막고 사용자 피드백을 개선합니다.
  - 스크롤 투탑 버튼 개선: 특정 페이지에서 자동 숨김 처리되어 보다 깔끔한 인터페이스를 제공합니다.
  - 프로필 수정 시 오류 메시지 표시 방식 개선: 오류 메시지가 팝업으로 간편하게 표시됩니다.

- **리팩토링**
  - 모달 및 폼 상태 관리 로직을 개선하여 전반적인 사용자 경험이 더욱 원활해졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->