### PR TITLE
fix: 지난 모임일 시 모임 취소 불가

### DIFF
--- a/src/app/(common)/gathering/_components/FloatingBar.tsx
+++ b/src/app/(common)/gathering/_components/FloatingBar.tsx
@@ -40,6 +40,7 @@ export default function FloatingBar({ gatheringId, gathering, hostUserId }: Floa
 
   const isHost = user?.id === hostUserId;
   const isJoined = user ? participantIdList?.includes(user?.id) : false;
+  const isValid = dayjs().isBefore(dayjs(registrationEnd));
 
   const closeModal = () => setActiveModal(null);
 
@@ -71,6 +72,7 @@ export default function FloatingBar({ gatheringId, gathering, hostUserId }: Floa
               size="sm"
               className={buttonStyles}
               onClick={() => setActiveModal(MODAL.cancel)}
+              disabled={!isValid}
               loading={isPendingCancel}
             >
               취소하기
@@ -116,7 +118,7 @@ export default function FloatingBar({ gatheringId, gathering, hostUserId }: Floa
               className={buttonStyles}
               onClick={() => mutateLeaveGathering(gatheringId)}
               loading={isPendingLeave}
-              disabled={dayjs(registrationEnd).isBefore(dayjs())}
+              disabled={!isValid}
             >
               참여 취소하기
             </Button>
@@ -127,7 +129,7 @@ export default function FloatingBar({ gatheringId, gathering, hostUserId }: Floa
               className={buttonStyles}
               onClick={handleJoin}
               loading={isPendingJoin}
-              disabled={isPendingJoin || dayjs(registrationEnd).isBefore(dayjs())}
+              disabled={isPendingJoin || !isValid}
             >
               참여하기
             </Button>

--- a/src/app/(common)/reviews/_components/AllReview.tsx
+++ b/src/app/(common)/reviews/_components/AllReview.tsx
@@ -101,7 +101,7 @@ export default function AllReview({ children, defaultQuery }: AllReviewProps) {
   }, []);
 
   return (
-    <div className="mt-9">
+    <div className="mt-6">
       <ServiceTab onCategoryChange={handleTypeChange} searchParams={searchParams} />
       <hr className="border-1 mb-6 mt-4" />
       {children}


### PR DESCRIPTION
## Description
지난 모임일 시 주최자는 모임을 취소하지 못하도록 처리하였습니다.

## Changes Made

- [x] 기능 추가: ✅

## Screenshots (선택)
<img width="755" alt="스크린샷 2025-03-11 오전 11 34 07" src="https://github.com/user-attachments/assets/c20b32d4-232a-43f3-b67c-da4b2a9a3b20" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- 등록 종료 시점을 기준으로 액션 버튼("취소하기", "참여 취소하기", "참여하기")의 활성/비활성 상태를 일관되게 개선하였습니다.
	- `AllReview` 컴포넌트의 마진을 조정하여 레이아웃을 개선하였습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->