### PR TITLE
MetaInfoProps의 imageUrl 타입을 인터섹션 타입으로 변경

### DIFF
--- a/src/components/ListItem.tsx
+++ b/src/components/ListItem.tsx
@@ -128,7 +128,7 @@ ListItem.ServiceInfo = ({ children }: { children: React.ReactNode }) => {
 
 // 리뷰 작성자의 정보
 type MetaInfoProps = {
-  imageUrl?: string;
+  imageUrl?: string | null;
   primary?: string;
   secondary: string;
 };


### PR DESCRIPTION
## Description

MetaInfoProps의 imageUrl 타입을 인터섹션 타입으로 변경
## Changes Made

[변경사항 리스트를 적습니다.]

- [x] 기능 추가: ✅

## Screenshots (선택)


## IssueNumber



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - 리스트 항목이 이미지 정보가 없거나 빈 값일 때도 안정적으로 처리되어 사용자 인터페이스의 일관성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->