### PR TITLE
fix:유효한 토큰이 아닐시 뜨는 팝업 로직 변경

### DIFF
--- a/src/components/TokenExpireHandler.tsx
+++ b/src/components/TokenExpireHandler.tsx
@@ -3,12 +3,13 @@
 import axiosInstance from "@/lib/axiosInstance";
 import { useUserStore } from "@/stores/useUserStore";
 import { useQueryClient } from "@tanstack/react-query";
-import { useRouter } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { LoginPopup } from "./Popup";
 
 export default function TokenExpireHandler() {
   const router = useRouter();
+  const pathname = usePathname();
   const [isModalOpen, setIsModalOpen] = useState(false);
   const queryClient = useQueryClient();
 
@@ -51,7 +52,13 @@ export default function TokenExpireHandler() {
           deleteCookie("token");
           deleteLocalStorage();
           signout();
-          setIsModalOpen(true);
+          if (pathname === "/mypage") {
+            setIsModalOpen(true);
+          } else if (pathname === "/") {
+            window.location.reload();
+          } else {
+            router.push("/");
+          }
         }
         return Promise.reject(error);
       },
@@ -60,7 +67,7 @@ export default function TokenExpireHandler() {
     return () => {
       axiosInstance.interceptors.response.eject(interceptor);
     };
-  }, [router]);
+  }, [router, pathname]);
 
   return <LoginPopup isOpen={isModalOpen} onClose={closeModal} />;
 }


### PR DESCRIPTION
## Description

유효한 토큰이 아닐 경우 뜨는 팝업을 mypage에서만 뜨게하고 다른페이지에선 로그아웃 시킨후 메인으로 이동시킵니다.
3번정도 테스트하고 pr올리는데 배포된 사이트에서 이상하게 동작한다면 알려주세요.

## Changes Made

- [x] 코드 리팩토링: 🔧

## Screenshots (선택)

[UI 변경사항이 있다면 스크린샷을 추가해주세요.]

## IssueNumber

[#이슈번호]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - 필터링과 데이터 로딩 경험이 향상되어, 목록과 즐겨찾기에서 자동으로 추가 데이터를 불러옵니다.
  - 참여 취소와 리뷰 작성 시 새로운 확인 모달 및 에러 팝업이 도입되어 사용자 인터랙션이 개선되었습니다.
  - 이벤트 카드 전역 클릭 및 조건부 스크롤-투-탑 버튼 처리로 보다 직관적인 내비게이션을 제공합니다.
  - 토큰 만료 처리 로직이 개선되어 상황에 맞게 안내됩니다.

- **Style**
  - 드롭다운, 날짜 선택기, 리뷰 및 기타 UI 구성 요소의 디자인과 배치가 세련되고 반응형으로 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->