### PR TITLE
마이페이지 - 컴포넌트 분리 및 시멘팅 태그

### DIFF
--- a/src/app/(common)/mypage/_components/MypageContent.tsx
+++ b/src/app/(common)/mypage/_components/MypageContent.tsx
@@ -100,7 +100,7 @@ export default function MypageContent() {
           </Tab.Item>
         ))}
       </Tab>
-      <div
+      <section
         className={`flex flex-1 flex-col ${selectedCategory !== "작성한 리뷰" ? "divide-y-2 divide-dashed" : "gap-6"}`}
       >
         <ErrorBoundary>
@@ -117,7 +117,7 @@ export default function MypageContent() {
             {selectedTab === "내가 만든 모임" && <MyCreatedGatherings />}
           </Suspense>
         </ErrorBoundary>
-      </div>
+      </section>
     </div>
   );
 }

--- a/src/app/(common)/mypage/_components/MypageContent.tsx
+++ b/src/app/(common)/mypage/_components/MypageContent.tsx
@@ -1,20 +1,14 @@
 "use client";
 
-import MyCreatedGatherings from "@/app/(common)/mypage/_components/MyCreatedGatherings";
-import MyGatherings from "@/app/(common)/mypage/_components/MyGatherings";
+import MypageContentSection from "@/app/(common)/mypage/_components/MypageContentSection";
 import MypageTab from "@/app/(common)/mypage/_components/MypageTab";
-import MyReviews from "@/app/(common)/mypage/_components/MyReviews";
-import ReviewableGatherings from "@/app/(common)/mypage/_components/ReviewableGatherings";
 import { useGetUserInfo } from "@/app/(common)/mypage/_hooks/useGetUserInfo";
 import useMypageTab from "@/app/(common)/mypage/_hooks/useMypageTab";
 import { MyGathering } from "@/app/(common)/mypage/types";
-import ErrorBoundary from "@/components/ErrorBoundary";
-import Spinner from "@/components/Spinner";
 import axiosInstance from "@/lib/axiosInstance";
 import { UserType, ReviewsResponse, GatheringType } from "@/types";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import dayjs from "dayjs";
-import { Suspense } from "react";
 
 // 나의 모임 -> 로그인된 사용자가 참석한 모임 목록 조회
 // 나의 리뷰 - 작성 가능한 리뷰 -> 로그인된 사용자가 참석한 모임 목록 조회 (리뷰 작성 여부 false 필터링)
@@ -74,24 +68,7 @@ export default function MypageContent() {
   return (
     <div className="flex flex-1 flex-col gap-6 border-t-2 border-gray-900 bg-white p-6">
       <MypageTab setSelectedCategory={setSelectedCategory} setSelectedTab={setSelectedTab} />
-      <section
-        className={`flex flex-1 flex-col ${selectedCategory !== "작성한 리뷰" ? "divide-y-2 divide-dashed" : "gap-6"}`}
-      >
-        <ErrorBoundary>
-          <Suspense
-            fallback={
-              <div className="flex flex-1 items-center justify-center">
-                <Spinner />
-              </div>
-            }
-          >
-            {selectedTab === "나의 모임" && <MyGatherings />}
-            {selectedTab === "나의 리뷰" && selectedCategory === "작성 가능한 리뷰" && <ReviewableGatherings />}
-            {selectedTab === "나의 리뷰" && selectedCategory === "작성한 리뷰" && <MyReviews />}
-            {selectedTab === "내가 만든 모임" && <MyCreatedGatherings />}
-          </Suspense>
-        </ErrorBoundary>
-      </section>
+      <MypageContentSection selectedTab={selectedTab} selectedCategory={selectedCategory} />
     </div>
   );
 }

--- a/src/app/(common)/mypage/_components/MypageContent.tsx
+++ b/src/app/(common)/mypage/_components/MypageContent.tsx
@@ -2,29 +2,24 @@
 
 import MyCreatedGatherings from "@/app/(common)/mypage/_components/MyCreatedGatherings";
 import MyGatherings from "@/app/(common)/mypage/_components/MyGatherings";
+import MypageTab from "@/app/(common)/mypage/_components/MypageTab";
 import MyReviews from "@/app/(common)/mypage/_components/MyReviews";
 import ReviewableGatherings from "@/app/(common)/mypage/_components/ReviewableGatherings";
 import { useGetUserInfo } from "@/app/(common)/mypage/_hooks/useGetUserInfo";
 import useMypageTab from "@/app/(common)/mypage/_hooks/useMypageTab";
 import { MyGathering } from "@/app/(common)/mypage/types";
-import CategoryButton from "@/components/CategoryButton";
 import ErrorBoundary from "@/components/ErrorBoundary";
 import Spinner from "@/components/Spinner";
-import Tab from "@/components/Tab";
 import axiosInstance from "@/lib/axiosInstance";
 import { UserType, ReviewsResponse, GatheringType } from "@/types";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import dayjs from "dayjs";
 import { Suspense } from "react";
 
-const TAB_ITEMS = ["나의 모임", "나의 리뷰", "내가 만든 모임"];
-const CATEGORIES = ["작성 가능한 리뷰", "작성한 리뷰"];
-
 // 나의 모임 -> 로그인된 사용자가 참석한 모임 목록 조회
 // 나의 리뷰 - 작성 가능한 리뷰 -> 로그인된 사용자가 참석한 모임 목록 조회 (리뷰 작성 여부 false 필터링)
 // 나의 리뷰 - 작성한 리뷰 -> 리뷰 목록 조회 (사용자 id로 필터링)
 // 내가 만든 모임 -> 모임 목록 조회 (모임 생성자(id) 로 필터링)
-
 export default function MypageContent() {
   const queryClient = useQueryClient();
   const { selectedTab, setSelectedTab, selectedCategory, setSelectedCategory } = useMypageTab();
@@ -78,28 +73,7 @@ export default function MypageContent() {
   });
   return (
     <div className="flex flex-1 flex-col gap-6 border-t-2 border-gray-900 bg-white p-6">
-      <Tab
-        category={
-          <CategoryButton categories={CATEGORIES} setValue={setSelectedCategory}>
-            {CATEGORIES.map((category) => (
-              <CategoryButton.Title key={category} category={category} />
-            ))}
-          </CategoryButton>
-        }
-        targetIndex={1}
-      >
-        {TAB_ITEMS.map((tabItem, idx) => (
-          <Tab.Item key={tabItem} index={idx}>
-            <button
-              onClick={() => {
-                setSelectedTab(tabItem);
-              }}
-            >
-              {tabItem}
-            </button>
-          </Tab.Item>
-        ))}
-      </Tab>
+      <MypageTab setSelectedCategory={setSelectedCategory} setSelectedTab={setSelectedTab} />
       <section
         className={`flex flex-1 flex-col ${selectedCategory !== "작성한 리뷰" ? "divide-y-2 divide-dashed" : "gap-6"}`}
       >

--- a/src/app/(common)/mypage/_components/MypageContentSection.tsx
+++ b/src/app/(common)/mypage/_components/MypageContentSection.tsx
@@ -1,0 +1,35 @@
+import MyCreatedGatherings from "@/app/(common)/mypage/_components/MyCreatedGatherings";
+import MyGatherings from "@/app/(common)/mypage/_components/MyGatherings";
+import MyReviews from "@/app/(common)/mypage/_components/MyReviews";
+import ReviewableGatherings from "@/app/(common)/mypage/_components/ReviewableGatherings";
+import ErrorBoundary from "@/components/ErrorBoundary";
+import { Spinner } from "flowbite-react";
+import { Suspense } from "react";
+
+type MypageContentSectionProps = {
+  selectedTab: string;
+  selectedCategory: string;
+};
+
+export default function MypageContentSection({ selectedTab, selectedCategory }: MypageContentSectionProps) {
+  return (
+    <section
+      className={`flex flex-1 flex-col ${selectedCategory !== "작성한 리뷰" ? "divide-y-2 divide-dashed" : "gap-6"}`}
+    >
+      <ErrorBoundary>
+        <Suspense
+          fallback={
+            <div className="flex flex-1 items-center justify-center">
+              <Spinner />
+            </div>
+          }
+        >
+          {selectedTab === "나의 모임" && <MyGatherings />}
+          {selectedTab === "나의 리뷰" && selectedCategory === "작성 가능한 리뷰" && <ReviewableGatherings />}
+          {selectedTab === "나의 리뷰" && selectedCategory === "작성한 리뷰" && <MyReviews />}
+          {selectedTab === "내가 만든 모임" && <MyCreatedGatherings />}
+        </Suspense>
+      </ErrorBoundary>
+    </section>
+  );
+}

--- a/src/app/(common)/mypage/_components/MypageTab.tsx
+++ b/src/app/(common)/mypage/_components/MypageTab.tsx
@@ -1,0 +1,36 @@
+import CategoryButton from "@/components/CategoryButton";
+import Tab from "@/components/Tab";
+
+const TAB_ITEMS = ["나의 모임", "나의 리뷰", "내가 만든 모임"];
+const CATEGORIES = ["작성 가능한 리뷰", "작성한 리뷰"];
+
+type MypageTabProps = {
+  setSelectedTab: (tab: string) => void;
+  setSelectedCategory: (category: string) => void;
+};
+export default function MypageTab({ setSelectedTab, setSelectedCategory }: MypageTabProps) {
+  return (
+    <Tab
+      category={
+        <CategoryButton categories={CATEGORIES} setValue={setSelectedCategory}>
+          {CATEGORIES.map((category) => (
+            <CategoryButton.Title key={category} category={category} />
+          ))}
+        </CategoryButton>
+      }
+      targetIndex={1}
+    >
+      {TAB_ITEMS.map((tabItem, idx) => (
+        <Tab.Item key={tabItem} index={idx}>
+          <button
+            onClick={() => {
+              setSelectedTab(tabItem);
+            }}
+          >
+            {tabItem}
+          </button>
+        </Tab.Item>
+      ))}
+    </Tab>
+  );
+}

--- a/src/app/(common)/mypage/_components/ReviewModal/CommentInput.tsx
+++ b/src/app/(common)/mypage/_components/ReviewModal/CommentInput.tsx
@@ -1,11 +1,11 @@
 import { ReviewFormValues } from "@/app/(common)/mypage/_hooks/useReviewForm";
 import { Control, Controller, FieldErrors } from "react-hook-form";
 
-interface CommentInputProps {
+type CommentInputProps = {
   control: Control<ReviewFormValues>;
   errors: FieldErrors<ReviewFormValues>;
   commentLength: number;
-}
+};
 
 export default function CommentInput({ control, errors, commentLength }: CommentInputProps) {
   return (

--- a/src/app/(common)/mypage/_components/ReviewModal/ReviewModal.tsx
+++ b/src/app/(common)/mypage/_components/ReviewModal/ReviewModal.tsx
@@ -7,11 +7,11 @@ import { useReviewForm } from "@/app/(common)/mypage/_hooks/useReviewForm";
 import RatingInput from "@/app/(common)/mypage/_components/ReviewModal/RatingInput";
 import { Popup } from "@/components/Popup";
 
-interface ReviewModalProps {
+type ReviewModalProps = {
   isOpen: boolean;
   onClose: () => void;
   gatheringId: number;
-}
+};
 
 export default function ReviewModal({ isOpen, onClose, gatheringId }: ReviewModalProps) {
   const {

--- a/src/app/(common)/mypage/utils/apis.ts
+++ b/src/app/(common)/mypage/utils/apis.ts
@@ -4,10 +4,10 @@ import { CardData } from "@/stores/useGatheringStore";
 import { GatheringType, ReviewsResponse } from "@/types";
 import dayjs from "dayjs";
 
-interface FetchMyGatheringsParams {
+type FetchMyGatheringsParams = {
   completed?: boolean;
   reviewed?: boolean;
-}
+};
 
 const fetchMyGatherings = async (query?: FetchMyGatheringsParams, isReviewable?: boolean) => {
   const response = await axiosInstance.get<MyGathering[]>("gatherings/joined", {


### PR DESCRIPTION
## Description

마이페이지에서 사용되는 컴포넌트를 분리하고 시멘틱 태그를 사용했습니다.

## Changes Made

[변경사항 리스트를 적습니다.]

- [x] 코드 리팩토링: 🔧

- 큰 변경사항은 없고 컴포넌트 분리와 시맨틱 태그 사용했습니다.
- interface로 선언된 타입들을 type으로 바꿔줬습니다.

## Screenshots (선택)

[UI 변경사항이 있다면 스크린샷을 추가해주세요.]

## IssueNumber

#202


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- My Page에 새로운 탭 네비게이션 기능이 추가되어, 카테고리와 탭 간 전환이 한층 직관적으로 개선되었습니다.
	- 새 콘텐츠 섹션 도입으로 모임 및 리뷰 항목의 로딩과 표시가 최적화되었습니다.
- **Refactor**
	- My Page의 콘텐츠 레이아웃이 단순화되어 전반적인 사용자 인터페이스 일관성과 반응성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->