### PR TITLE
마이페이지 - 에러 핸들링 및 staleTime설정

### DIFF
--- a/src/app/(common)/mypage/_components/MypageList.tsx
+++ b/src/app/(common)/mypage/_components/MypageList.tsx
@@ -13,7 +13,7 @@ export default function MypageList<T extends MyGathering | ReviewResponse | Gath
   emptyMessage,
   queryOption,
 }: GatheringListProps<T>) {
-  const { data, error } = useSuspenseQuery({ ...queryOption });
+  const { data, error } = useSuspenseQuery({ ...queryOption, staleTime: 300000 });
 
   if (error) {
     return (

--- a/src/app/(common)/mypage/_hooks/useMypageModal.ts
+++ b/src/app/(common)/mypage/_hooks/useMypageModal.ts
@@ -2,7 +2,7 @@ import { useState } from "react";
 
 export default function useMypageModal() {
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const [selectedGathering, setSelectedGathering] = useState<number>();
+  const [selectedGathering, setSelectedGathering] = useState<number | null>(null);
 
   const handleOpen = (gatheringId: number) => {
     setSelectedGathering(gatheringId);

--- a/src/app/(common)/mypage/_hooks/usePostReviews.ts
+++ b/src/app/(common)/mypage/_hooks/usePostReviews.ts
@@ -1,12 +1,32 @@
 import axiosInstance from "@/lib/axiosInstance";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { isAxiosError } from "axios";
 
 const postReviews = async (reviewData: { gatheringId: number; score: number; comment: string }) => {
   try {
     const { data } = await axiosInstance.post(`/reviews`, reviewData);
     return data;
   } catch (error) {
-    throw new Error("데이터를 불러오지 못했습니다.");
+    if (isAxiosError(error)) {
+      const { response, request } = error;
+
+      if (response) {
+        // 서버에서 응답이 온 경우
+        const { status, data } = response;
+
+        if (status === 403) throw new Error("참석한 모임이 아닙니다.");
+        if (status === 404 && data.message === "모임을 찾을 수 없습니다") {
+          throw new Error("해당 모임을 찾을 수 없습니다");
+        }
+
+        throw new Error(data.message || "리뷰 작성 중 오류가 발생했습니다.");
+      } else if (request) {
+        // 요청이 이루어졌지만 응답을 받지 못한 경우
+        throw new Error("서버로부터 응답이 없습니다. 네트워크 상태를 확인해주세요.");
+      }
+    }
+
+    throw new Error("알 수 없는 오류가 발생했습니다.");
   }
 };
 

--- a/src/app/(common)/mypage/_hooks/useProfileEditForm.ts
+++ b/src/app/(common)/mypage/_hooks/useProfileEditForm.ts
@@ -39,7 +39,7 @@ export function useProfileEditForm(isOpen: boolean, onClose: () => void) {
       profileForm.reset({ companyName: data?.companyName, profileImg: undefined });
       setPreviewUrl(data?.image || "");
     }
-  }, [isOpen, data?.companyName, data?.image]);
+  }, [isOpen]);
 
   // 폼 제출 로직
   const onSubmit = (data: FormValues) => {

--- a/src/app/(common)/mypage/_hooks/useUpdateUserInfo.ts
+++ b/src/app/(common)/mypage/_hooks/useUpdateUserInfo.ts
@@ -15,9 +15,6 @@ const updateUserInfo = async (formData: FormData) => {
     if (isAxiosError(error)) {
       // 응답 자체는 온 경우
       if (error.response) {
-        if (error.response?.status === 401) {
-          throw new Error("인증 실패! 재로그인 해주세요.");
-        }
         if (error.response?.status === 404) {
           throw new Error("사용자를 찾을 수 없습니다.");
         }

--- a/src/app/api/getUser.ts
+++ b/src/app/api/getUser.ts
@@ -22,7 +22,6 @@ export const getUser = async (): Promise<User> => {
       if (response) {
         // 서버에서 응답은 있었음
         const { status, data } = response;
-        if (status === 401) throw new Error("인증 실패. 재로그인 해주세요.");
         if (status === 404) {
           if (data.message === "사용자를 찾을 수 없습니다.") {
             throw new Error("사용자를 찾을 수 없습니다.");

--- a/src/app/api/getUser.ts
+++ b/src/app/api/getUser.ts
@@ -1,4 +1,5 @@
 import axiosInstance from "@/lib/axiosInstance";
+import { isAxiosError } from "axios";
 
 export type User = {
   teamId: number;
@@ -12,6 +13,21 @@ export type User = {
 };
 
 export const getUser = async (): Promise<User> => {
-  const response = await axiosInstance.get<User>("auths/user");
-  return response.data;
+  try {
+    const response = await axiosInstance.get<User>("auths/user");
+    return response.data;
+  } catch (error) {
+    if (isAxiosError(error)) {
+      const { response, request } = error;
+      if (response) {
+        // 서버에서 응답은 있었음
+        const { status, data } = response;
+        if (status === 401) throw new Error("인증 실패. 재로그인 해주세요.");
+        if (status === 404) throw new Error("사용자를 찾을 수 없습니다.");
+      } else if (request) {
+        throw new Error("서버로부터 응답이 없습니다. 네트워크 상태를 확인해주세요.");
+      }
+    }
+    throw new Error("알 수 없는 오류가 발생했습니다.");
+  }
 };

--- a/src/app/api/getUser.ts
+++ b/src/app/api/getUser.ts
@@ -23,7 +23,11 @@ export const getUser = async (): Promise<User> => {
         // 서버에서 응답은 있었음
         const { status, data } = response;
         if (status === 401) throw new Error("인증 실패. 재로그인 해주세요.");
-        if (status === 404) throw new Error("사용자를 찾을 수 없습니다.");
+        if (status === 404) {
+          if (data.message === "사용자를 찾을 수 없습니다.") {
+            throw new Error("사용자를 찾을 수 없습니다.");
+          }
+        }
       } else if (request) {
         throw new Error("서버로부터 응답이 없습니다. 네트워크 상태를 확인해주세요.");
       }


### PR DESCRIPTION
## Description

마이페이지에 사용되는 api요청의 에러핸들링, MypageList의 staleTime을 설정, 의존성 배열을 수정했습니다.

## Changes Made

[변경사항 리스트를 적습니다.]

- [x] 기능 추가: ✅
- [x] 코드 리팩토링: 🔧

- 리뷰 작성, 회원 정보 불러오기에 에러 핸들링 로직 추가했습니다.
- MypageList에서 사용하는 데이터들의 staleTIme을 5분으로 설정했습니다.
- useProfileEditForm에서 두번째 useEffect(초기화)의 의존성 배열을 수정했습니다.

## Screenshots (선택)

[UI 변경사항이 있다면 스크린샷을 추가해주세요.]

## IssueNumber

[#이슈번호]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **리팩터**
  - 마이페이지에서 데이터 캐싱 시간이 5분으로 연장되어 보다 안정적인 로딩 경험을 제공합니다.
  - 모달에서 선택 상태 초기화를 개선하여 인터페이스 일관성이 향상되었습니다.
  - 프로필 편집 모달의 초기화 조건을 변경하여 불필요한 업데이트를 방지합니다.

- **버그 수정**
  - 리뷰 작성 시 발생하는 오류에 대해 보다 구체적인 안내 메시지를 제공합니다.
  - 사용자 정보 요청 오류 처리 로직을 강화해 명확한 피드백을 제공합니다.
  - 인증 실패에 대한 오류 처리를 제거하여 간소화된 사용자 경험을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->