### PR TITLE
Fix: 화면 깜빡임 버그 수정, 컴포넌트 분리 및 공용 type 사용

### DIFF
--- a/src/app/(common)/_home/CardList.tsx
+++ b/src/app/(common)/_home/CardList.tsx
@@ -3,12 +3,10 @@
 import CreateGatheringsModal from "@/app/(common)/_home/_components/CreateGatheringsModal";
 import GatheringFilters from "@/app/(common)/_home/_components/GatheringFilters";
 import Button from "@/components/Button";
-import Card from "@/components/Card";
 import { LoginPopup } from "@/components/Popup";
 import ServiceTab from "@/components/ServiceTab";
 import HeaderSection from "./_components/HeaderSection";
 import GatheringList from "./_components/GatheringList";
-import { useInfiniteScroll } from "@/hooks/useInfiniteScroll";
 import { useFilters } from "@/app/(common)/_home/_hooks/useFilters";
 import { useAuth } from "@/app/(common)/_home/_hooks/useAuth";
 import { useState, useEffect } from "react";

--- a/src/app/(common)/_home/CardList.tsx
+++ b/src/app/(common)/_home/CardList.tsx
@@ -6,18 +6,17 @@ import Button from "@/components/Button";
 import Card from "@/components/Card";
 import { LoginPopup } from "@/components/Popup";
 import ServiceTab from "@/components/ServiceTab";
+import HeaderSection from "./_components/HeaderSection";
+import GatheringList from "./_components/GatheringList";
 import { useInfiniteScroll } from "@/hooks/useInfiniteScroll";
 import { useFilters } from "@/app/(common)/_home/_hooks/useFilters";
-import { useGatherings } from "@/app/(common)/_home/_hooks/useGathering";
 import { useAuth } from "@/app/(common)/_home/_hooks/useAuth";
-import GatheringLogo from "@/images/gathering_logo.svg";
 import { useState, useEffect } from "react";
 
 export default function CardList() {
   const { filters, handleFilterChange, isFilteringLoading } = useFilters(); // 필터 관리 적용
-  const { filteredCards, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading, dataFetched } =
-    useGatherings(filters);
   const { checkAuth, isAuthModalOpen, setAuthModalOpen, shouldOpenCreateModal, setShouldOpenCreateModal } = useAuth(); // 로그인 체크 적용
+
   const [isModalOpen, setIsModalOpen] = useState(false);
 
   useEffect(() => {
@@ -35,18 +34,9 @@ export default function CardList() {
   };
   const handleClose = () => setIsModalOpen(false);
 
-  // 무한 스크롤 훅 사용
-  const { observerRef } = useInfiniteScroll({ fetchNextPage, hasNextPage, isFetchingNextPage });
-
   return (
     <div>
-      <div className="mb-5 flex flex-row items-center gap-4 pl-3 pt-10">
-        <GatheringLogo />
-        <div>
-          <div className="mb-2 text-sm font-semibold text-gray-700">함께할 사람이 없나요?</div>
-          <div className="text-lg font-semibold text-gray-900 lg:text-2xl">지금 모임에 참여해보세요</div>
-        </div>
-      </div>
+      <HeaderSection />
       <div className="relative mt-6">
         <div className="flex flex-row">
           <ServiceTab
@@ -77,23 +67,8 @@ export default function CardList() {
       <hr className="my-3" />
       <div>
         <GatheringFilters onChange={handleFilterChange} />
-
-        {isLoading ? (
-          <div className="flex h-[calc(100vh-50vh)] flex-col items-center justify-center text-center text-sm font-medium text-gray-500">
-            <p>모임 정보를 불러오는 중...</p>
-          </div>
-        ) : filteredCards.length === 0 ? (
-          <div className="flex h-[calc(100vh-50vh)] flex-col items-center justify-center text-center text-sm font-medium text-gray-500">
-            <p>아직 모임이 없어요</p>
-            <p className="mt-2">지금 바로 모임을 만들어보세요</p>
-          </div>
-        ) : (
-          filteredCards.map((card) => <Card key={card.id} {...card} registrationEnd={card.registrationEnd ?? ""} />)
-        )}
-        {!isLoading && <div ref={observerRef} className="h-10"></div>}
-        {!isLoading && isFetchingNextPage && <div className="text-center text-sm text-gray-500">불러오는 중...</div>}
+        <GatheringList filters={filters} />
       </div>
-
       <CreateGatheringsModal isOpen={isModalOpen} onClose={handleClose} />
     </div>
   );

--- a/src/app/(common)/_home/_components/GatheringFilters.tsx
+++ b/src/app/(common)/_home/_components/GatheringFilters.tsx
@@ -6,9 +6,10 @@ import { format } from "date-fns";
 import DateSelect from "@/components/Filtering/DateSelect";
 import LocationSelect from "@/components/Filtering/LocationSelect";
 import SortButton from "@/components/SortButton";
+import { FiltersType } from "@/types";
 
 type GatheringFiltersProps = {
-  onChange: (filters: Partial<{ location?: string; date?: string; sortBy?: string }>) => void;
+  onChange: (filters: Partial<FiltersType>) => void;
 };
 
 const sortOption = [

--- a/src/app/(common)/_home/_components/GatheringList.tsx
+++ b/src/app/(common)/_home/_components/GatheringList.tsx
@@ -1,0 +1,38 @@
+import { useGatherings } from "@/app/(common)/_home/_hooks/useGathering";
+import { useInfiniteScroll } from "@/hooks/useInfiniteScroll";
+import Card from "@/components/Card";
+import { FiltersType } from "@/types";
+
+const GatheringList = ({ filters }: { filters: FiltersType }) => {
+  const { filteredCards, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } = useGatherings(filters);
+  const { observerRef } = useInfiniteScroll({ fetchNextPage, hasNextPage, isFetchingNextPage });
+
+  if (isLoading) {
+    return (
+      <div className="flex h-[calc(100vh-50vh)] flex-col items-center justify-center text-center text-sm font-medium text-gray-500">
+        <p>모임 정보를 불러오는 중...</p>
+      </div>
+    );
+  }
+
+  if (filteredCards.length === 0) {
+    return (
+      <div className="flex h-[calc(100vh-50vh)] flex-col items-center justify-center text-center text-sm font-medium text-gray-500">
+        <p>아직 모임이 없어요</p>
+        <p className="mt-2">지금 바로 모임을 만들어보세요</p>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      {filteredCards.map((card) => (
+        <Card key={card.id} {...card} registrationEnd={card.registrationEnd ?? ""} />
+      ))}
+      <div ref={observerRef} className="h-10"></div>
+      {isFetchingNextPage && <div className="text-center text-sm text-gray-500">불러오는 중...</div>}
+    </>
+  );
+};
+
+export default GatheringList;

--- a/src/app/(common)/_home/_components/GatheringList.tsx
+++ b/src/app/(common)/_home/_components/GatheringList.tsx
@@ -15,7 +15,7 @@ const GatheringList = ({ filters }: { filters: FiltersType }) => {
     );
   }
 
-  if (filteredCards.length === 0) {
+  if (!hasNextPage && filteredCards.length === 0) {
     return (
       <div className="flex h-[calc(100vh-50vh)] flex-col items-center justify-center text-center text-sm font-medium text-gray-500">
         <p>아직 모임이 없어요</p>
@@ -30,7 +30,6 @@ const GatheringList = ({ filters }: { filters: FiltersType }) => {
         <Card key={card.id} {...card} registrationEnd={card.registrationEnd ?? ""} />
       ))}
       <div ref={observerRef} className="h-10"></div>
-      {isFetchingNextPage && <div className="text-center text-sm text-gray-500">불러오는 중...</div>}
     </>
   );
 };

--- a/src/app/(common)/_home/_components/HeaderSection.tsx
+++ b/src/app/(common)/_home/_components/HeaderSection.tsx
@@ -1,0 +1,13 @@
+import GatheringLogo from "@/images/gathering_logo.svg";
+
+const HeaderSection = () => (
+  <div className="mb-5 flex flex-row items-center gap-4 pl-3 pt-10">
+    <GatheringLogo />
+    <div>
+      <div className="mb-2 text-sm font-semibold text-gray-700">함께할 사람이 없나요?</div>
+      <div className="text-lg font-semibold text-gray-900 lg:text-2xl">지금 모임에 참여해보세요</div>
+    </div>
+  </div>
+);
+
+export default HeaderSection;

--- a/src/app/(common)/_home/_hooks/useFetchGatherings.ts
+++ b/src/app/(common)/_home/_hooks/useFetchGatherings.ts
@@ -1,17 +1,10 @@
 import { useInfiniteQuery } from "@tanstack/react-query";
 import { GatheringType } from "@/types";
 import axiosInstance from "@/lib/axiosInstance";
-
-type FetchParams = {
-  location?: string;
-  date?: string;
-  type?: string;
-  sortBy?: string;
-  sortOrder?: "asc"; // 오름차순 정렬
-};
+import { FiltersType } from "@/types";
 
 // type 기본값 설정
-const defaultFilters: FetchParams = {
+const defaultFilters: FiltersType = {
   type: "DALLAEMFIT",
 };
 
@@ -21,7 +14,7 @@ export const fetchGatherings = async ({
   filters = {},
 }: {
   pageParam: number;
-  filters?: FetchParams;
+  filters?: FiltersType;
 }) => {
   try {
     const mergedFilters = { ...defaultFilters, ...filters };
@@ -41,7 +34,7 @@ export const fetchGatherings = async ({
 };
 
 // 클라이언트에서 무한스크롤을 위한 데이터 패칭
-export const useFetchGatherings = (filters?: FetchParams) => {
+export const useFetchGatherings = (filters?: FiltersType) => {
   return useInfiniteQuery({
     queryKey: ["gatherings", filters],
     queryFn: ({ pageParam = 0 }) => fetchGatherings({ pageParam, filters }),

--- a/src/app/(common)/_home/_hooks/useFilters.ts
+++ b/src/app/(common)/_home/_hooks/useFilters.ts
@@ -17,7 +17,7 @@ export const useFilters = () => {
     return {
       location: searchParams.get("location") || undefined,
       date: searchParams.get("date") || undefined,
-      sortBy: searchParams.get("sortBy") || "asc",
+      sortBy: searchParams.get("sortBy") || undefined,
       type: searchParams.get("type") || "DALLAEMFIT",
     };
   }, [searchParamsString]);

--- a/src/app/(common)/_home/_hooks/useFilters.ts
+++ b/src/app/(common)/_home/_hooks/useFilters.ts
@@ -2,6 +2,7 @@
 
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useMemo, useCallback, useState, useEffect } from "react";
+import { FiltersType } from "@/types";
 
 export const useFilters = () => {
   const searchParams = useSearchParams();
@@ -12,11 +13,11 @@ export const useFilters = () => {
   const [isFilteringLoading, setIsFilteringLoading] = useState(false); // 필터링 로딩 상태 추가
 
   // searchParams에서 필터 값을 추출
-  const filters = useMemo(() => {
+  const filters: FiltersType = useMemo(() => {
     return {
       location: searchParams.get("location") || undefined,
       date: searchParams.get("date") || undefined,
-      sortBy: searchParams.get("sortBy") || undefined,
+      sortBy: searchParams.get("sortBy") || "asc",
       type: searchParams.get("type") || "DALLAEMFIT",
     };
   }, [searchParamsString]);

--- a/src/app/(common)/favorites/FavoriteList.tsx
+++ b/src/app/(common)/favorites/FavoriteList.tsx
@@ -36,7 +36,7 @@ export default function FavoriteList({
     );
   }
 
-  if (favoriteCards.length === 0) {
+  if (!hasNextPage && favoriteCards.length === 0) {
     return (
       <p className="flex h-[calc(100vh-50vh)] flex-col items-center justify-center text-center text-sm font-medium text-gray-500">
         아직 찜한 모임이 없습니다.
@@ -50,7 +50,6 @@ export default function FavoriteList({
         <Card key={card.id} {...card} registrationEnd={card.registrationEnd ?? ""} />
       ))}
       <div ref={observerRef} className="h-10"></div>
-      {isFetchingNextPage && <div className="text-center text-sm text-gray-500">불러오는 중...</div>}
     </>
   );
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,3 +51,11 @@ export type ReviewsResponse = {
   currentPage: number;
   totalPages: number;
 };
+
+export type FiltersType = {
+  location?: string;
+  date?: string;
+  type?: string;
+  sortBy?: string;
+  sortOrder?: "asc" | "desc";
+};


### PR DESCRIPTION
## Description

메인 모임 목록 불러올 때 "아직 모임이 없어요"가 불필요하게 먼저 뜨는 문제 해결했습니다. 
CardList 파일 단일 책임 원칙 적용하여 컴포넌트 분리했습니다. 

## Changes Made

- [x] 버그 수정: 🐛
- [x] 코드 리팩토링: 🔧

## Screenshots (선택)

## IssueNumber

[#이슈번호]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 직관적인 리스트 형식의 집회 목록이 새롭게 도입되어 참여할 집회를 한눈에 확인할 수 있습니다.
	- 로고와 안내 문구가 포함된 헤더 영역을 추가하여 사용자 인터페이스가 개선되었습니다.
  
- **리팩터**
	- 기존 카드 기반 무한 스크롤 방식을 간소화하여 보다 깔끔한 화면 구성이 이루어졌습니다.
	- 즐겨찾기 화면의 메시지 노출 조건이 개선되어 사용자 경험이 향상되었습니다.
	- 필터 기준이 통일되어 데이터 조회 방식이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->