### PR TITLE
fix: utc 기준 현재 날짜 비교

### DIFF
--- a/src/app/(common)/gathering/_components/FloatingBar.tsx
+++ b/src/app/(common)/gathering/_components/FloatingBar.tsx
@@ -9,8 +9,8 @@ import { useJoin } from "../_hooks/useJoin";
 import { useGetParticipants } from "../_hooks/useGetParticipants";
 import { useLeaveGathering } from "@/hooks/useLeaveGathering";
 import { useCancelGathering } from "../_hooks/useCancelGathering";
+import { isPastDate } from "@/utils/date";
 import type { GatheringType } from "@/types";
-import dayjs from "dayjs";
 
 type FloatingBarProps = {
   gatheringId: string;
@@ -41,7 +41,7 @@ export default function FloatingBar({ gatheringId, gathering, hostUserId }: Floa
 
   const isHost = user?.id === hostUserId;
   const isJoined = user ? participantIdList?.includes(user?.id) : false;
-  const isValid = dayjs().isBefore(dayjs(registrationEnd));
+  const isValid = !isPastDate(registrationEnd);
 
   const closeModal = () => setActiveModal(null);
 

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,0 +1,8 @@
+import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
+
+dayjs.extend(utc);
+
+export const isPastDate = (date: string) => {
+  return dayjs.utc(date).isBefore(dayjs.utc().add(9, "hour"));
+};


### PR DESCRIPTION
## Description
utc 날짜와 utc+9(현재 로컬 시간)을 비교하여 
파라미터로 받은 날짜가 현재 시간보다 과거이면 true를 리턴합니다.  

## Changes Made


- [x] 기능 추가: ✅


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - 등록 마감 시간 판별 방식을 개선하여 날짜 유효성 검사가 더욱 간결해졌습니다.
  - 내부 의존성을 줄이고 유지보수성을 향상시켰습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->