### PR TITLE
fix: 메인, 찜한 모임에서 progress bar 새로고침 시 적 용 안되는 문제 해결

### DIFF
--- a/src/components/AnimateParticipantCount.tsx
+++ b/src/components/AnimateParticipantCount.tsx
@@ -17,7 +17,7 @@ export default function AnimatedParticipantCount({ participantCount, capacity }:
 
   // 값이 변경될 때 애니메이션 적용
   useEffect(() => {
-    const controls = animate(count, participantCount, { duration: 1, ease: "easeOut" });
+    const controls = animate(count, participantCount, { duration: 0.6, ease: "easeOut" });
 
     return controls.stop; // 컴포넌트 언마운트 시 애니메이션 중지
   }, [participantCount]);

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -7,7 +7,7 @@ import { useFavoritesStore } from "@/stores/useFavoritesStore";
 import { GatheringType } from "@/types";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
-import React from "react";
+import React, { useMemo } from "react";
 import AnimatedParticipantCount from "./AnimateParticipantCount";
 import ChipInfo from "./ChipInfo";
 import LikeButton from "./LikeButton";
@@ -31,7 +31,11 @@ export default function Card({
   const router = useRouter();
   const { toggleFavorite, favorites } = useFavoritesStore();
 
-  const progress = capacity > 0 ? (participantCount / capacity) * 100 : 0;
+  const progress = useMemo(
+    () => (capacity > 0 ? (participantCount / capacity) * 100 : 0),
+    [participantCount, capacity],
+  );
+
   const now = dayjs().add(9, "hour").utc();
   const endDate = dayjs.utc(registrationEnd);
   const isClosed = Boolean(endDate && endDate.isBefore(now));

--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -16,7 +16,7 @@ export default function ProgressBar({ progress }: ProgressBarProps) {
   return (
     <div className="h-1.5 w-full rounded-full bg-sky-100">
       <div
-        className="h-1.5 rounded-full bg-primary-color transition-all duration-700 ease-in-out"
+        className="h-1.5 rounded-full bg-primary-color transition-all duration-1000 ease-in-out"
         style={{ width: `${animatedProgress}%` }}
       ></div>
     </div>

--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -10,7 +10,9 @@ export default function ProgressBar({ progress }: ProgressBarProps) {
   const [animatedProgress, setAnimatedProgress] = useState(0); // 초기값 0
 
   useEffect(() => {
-    setAnimatedProgress(progress); // progress 변경 시 애니메이션 적용
+    window.setTimeout(() => {
+      setAnimatedProgress(progress); // progress 변경 시 애니메이션 적용
+    }, 10); // 짧은 딜레이 추가
   }, [progress]);
 
   return (


### PR DESCRIPTION
## Description

모임 찾기와 찜한 모임에서 새로고침 시 progress bar 애니메이션이 적용 안되는 버그 수정했습니다. 

## Changes Made

- [x] 버그 수정: 🐛

## Screenshots (선택)


## IssueNumber

[#이슈번호]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **리팩터**
	- 참가자 수 애니메이션이 더 빠르게 반응하도록 지속 시간을 단축했습니다.
	- 진행률 계산 로직을 최적화하여 불필요한 업데이트를 줄였습니다.
- **스타일**
	- 진행 바의 전환 효과에 약간의 지연 및 더 긴 애니메이션 효과를 적용해 부드러운 시각적 전환을 구현했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->